### PR TITLE
WIP: Update label shortcodes

### DIFF
--- a/data/136/251/273/136251273.geojson
+++ b/data/136/251/273/136251273.geojson
@@ -15,6 +15,9 @@
     "gn:population":7730612,
     "iso:country":"CA",
     "iso:subdivision":"CA-QC",
+    "label:eng_x_preferred_abbreviation":[
+        "Que."
+    ],
     "label:eng_x_preferred_longname":[
         "Quebec Province"
     ],
@@ -23,6 +26,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "QC"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "Qc"
     ],
     "lbl:latitude":52.03334,
     "lbl:longitude":-72.765013,
@@ -678,7 +684,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640796,
+    "wof:lastmodified":1565642880,
     "wof:name":"Quebec",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/136/251/273/136251273.geojson
+++ b/data/136/251/273/136251273.geojson
@@ -21,6 +21,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "QC"
+    ],
     "lbl:latitude":52.03334,
     "lbl:longitude":-72.765013,
     "mps:latitude":52.03334,
@@ -665,9 +668,6 @@
         }
     ],
     "wof:id":136251273,
-    "wof:lang":[
-        "fre"
-    ],
     "wof:lang_x_official":[
         "eng",
         "fra"
@@ -678,7 +678,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563283868,
+    "wof:lastmodified":1565640796,
     "wof:name":"Quebec",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/330/41/85633041.geojson
+++ b/data/856/330/41/85633041.geojson
@@ -16,6 +16,9 @@
     "itu:country_code":[
         "1"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "CA"
+    ],
     "lbl:latitude":58.33747,
     "lbl:longitude":-112.384858,
     "mps:latitude":58.33747,
@@ -1041,9 +1044,6 @@
         }
     ],
     "wof:id":85633041,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "eng",
         "fra"
@@ -1054,7 +1054,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281728,
+    "wof:lastmodified":1565640673,
     "wof:name":"Canada",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/820/57/85682057.geojson
+++ b/data/856/820/57/85682057.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-85.830446,
     "iso:country":"CA",
     "iso:subdivision":"CA-ON",
+    "label:eng_x_preferred_abbreviation":[
+        "Ont."
+    ],
     "label:eng_x_preferred_longname":[
         "Ontario Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "ON"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "Ont."
     ],
     "lbl:latitude":51.451405,
     "lbl:longitude":-85.835963,
@@ -574,7 +580,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640679,
+    "wof:lastmodified":1565642882,
     "wof:name":"Ontario",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/57/85682057.geojson
+++ b/data/856/820/57/85682057.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "ON"
+    ],
     "lbl:latitude":51.451405,
     "lbl:longitude":-85.835963,
     "mps:latitude":51.451405,
@@ -571,7 +574,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281741,
+    "wof:lastmodified":1565640679,
     "wof:name":"Ontario",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/65/85682065.geojson
+++ b/data/856/820/65/85682065.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-66.33521,
     "iso:country":"CA",
     "iso:subdivision":"CA-NB",
+    "label:eng_x_preferred_abbreviation":[
+        "N.B."
+    ],
     "label:eng_x_preferred_longname":[
         "New Brunswick Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "NB"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "N.-B."
     ],
     "lbl:latitude":46.595511,
     "lbl:longitude":-66.334856,
@@ -525,7 +531,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640683,
+    "wof:lastmodified":1565642879,
     "wof:name":"New Brunswick",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/65/85682065.geojson
+++ b/data/856/820/65/85682065.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NB"
+    ],
     "lbl:latitude":46.595511,
     "lbl:longitude":-66.334856,
     "mps:latitude":46.595511,
@@ -522,7 +525,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281756,
+    "wof:lastmodified":1565640683,
     "wof:name":"New Brunswick",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/67/85682067.geojson
+++ b/data/856/820/67/85682067.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-119.128892,
     "iso:country":"CA",
     "iso:subdivision":"CA-NT",
+    "label:eng_x_preferred_abbreviation":[
+        "N.W.T."
+    ],
     "label:eng_x_preferred_longname":[
         "Northwest Territories Territory"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "NT"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "T.N.-O."
     ],
     "lbl:latitude":66.146924,
     "lbl:longitude":-125.335712,
@@ -514,7 +520,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640680,
+    "wof:lastmodified":1565642888,
     "wof:name":"Northwest Territories",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/67/85682067.geojson
+++ b/data/856/820/67/85682067.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "territory"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NT"
+    ],
     "lbl:latitude":66.146924,
     "lbl:longitude":-125.335712,
     "mps:latitude":66.146924,
@@ -511,7 +514,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281744,
+    "wof:lastmodified":1565640680,
     "wof:name":"Northwest Territories",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/75/85682075.geojson
+++ b/data/856/820/75/85682075.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-63.280038,
     "iso:country":"CA",
     "iso:subdivision":"CA-NS",
+    "label:eng_x_preferred_abbreviation":[
+        "N.S."
+    ],
     "label:eng_x_preferred_longname":[
         "Nova Scotia Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "NS"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "N.-\u00c9."
     ],
     "lbl:latitude":45.226989,
     "lbl:longitude":-63.509537,
@@ -537,7 +543,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640682,
+    "wof:lastmodified":1565642879,
     "wof:name":"Nova Scotia",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/75/85682075.geojson
+++ b/data/856/820/75/85682075.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NS"
+    ],
     "lbl:latitude":45.226989,
     "lbl:longitude":-63.509537,
     "mps:latitude":45.226989,
@@ -534,7 +537,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281749,
+    "wof:lastmodified":1565640682,
     "wof:name":"Nova Scotia",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/81/85682081.geojson
+++ b/data/856/820/81/85682081.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "PE"
+    ],
     "lbl:latitude":46.196558,
     "lbl:longitude":-62.735184,
     "mps:latitude":46.196558,
@@ -515,7 +518,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281750,
+    "wof:lastmodified":1565640682,
     "wof:name":"Prince Edward Island",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/81/85682081.geojson
+++ b/data/856/820/81/85682081.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-63.256369,
     "iso:country":"CA",
     "iso:subdivision":"CA-PE",
+    "label:eng_x_preferred_abbreviation":[
+        "P.E.I."
+    ],
     "label:eng_x_preferred_longname":[
         "Prince Edward Island Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "PE"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "\u00ce.-P.-\u00c9."
     ],
     "lbl:latitude":46.196558,
     "lbl:longitude":-62.735184,
@@ -518,7 +524,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640682,
+    "wof:lastmodified":1565642879,
     "wof:name":"Prince Edward Island",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/85/85682085.geojson
+++ b/data/856/820/85/85682085.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-97.435069,
     "iso:country":"CA",
     "iso:subdivision":"CA-MB",
+    "label:eng_x_preferred_abbreviation":[
+        "Man."
+    ],
     "label:eng_x_preferred_longname":[
         "Manitoba Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "MB"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "Man."
     ],
     "lbl:latitude":55.614438,
     "lbl:longitude":-97.960389,
@@ -546,7 +552,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640683,
+    "wof:lastmodified":1565642883,
     "wof:name":"Manitoba",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/85/85682085.geojson
+++ b/data/856/820/85/85682085.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MB"
+    ],
     "lbl:latitude":55.614438,
     "lbl:longitude":-97.960389,
     "mps:latitude":55.614438,
@@ -543,7 +546,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281758,
+    "wof:lastmodified":1565640683,
     "wof:name":"Manitoba",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/91/85682091.geojson
+++ b/data/856/820/91/85682091.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AB"
+    ],
     "lbl:latitude":55.44167,
     "lbl:longitude":-114.446928,
     "mps:latitude":55.44167,
@@ -540,7 +543,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281753,
+    "wof:lastmodified":1565640682,
     "wof:name":"Alberta",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/91/85682091.geojson
+++ b/data/856/820/91/85682091.geojson
@@ -15,7 +15,7 @@
     "iso:country":"CA",
     "iso:subdivision":"CA-AB",
     "label:eng_x_preferred_abbreviation":[
-        "Alta."
+        "Alb."
     ],
     "label:eng_x_preferred_longname":[
         "Alberta Province"
@@ -25,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "AB"
+    ],
+    "label:eng_x_variant_abbreviation":[
+        "Alta."
     ],
     "label:fra_x_preferred_abbreviation":[
         "Alb."
@@ -549,7 +552,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565642884,
+    "wof:lastmodified":1565646055,
     "wof:name":"Alberta",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/91/85682091.geojson
+++ b/data/856/820/91/85682091.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-114.513165,
     "iso:country":"CA",
     "iso:subdivision":"CA-AB",
+    "label:eng_x_preferred_abbreviation":[
+        "Alta."
+    ],
     "label:eng_x_preferred_longname":[
         "Alberta Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "AB"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "Alb."
     ],
     "lbl:latitude":55.44167,
     "lbl:longitude":-114.446928,
@@ -543,7 +549,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640682,
+    "wof:lastmodified":1565642884,
     "wof:name":"Alberta",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/95/85682095.geojson
+++ b/data/856/820/95/85682095.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-135.513153,
     "iso:country":"CA",
     "iso:subdivision":"CA-YT",
+    "label:eng_x_preferred_abbreviation":[
+        "Y.T."
+    ],
     "label:eng_x_preferred_longname":[
         "Yukon Territory"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "YT"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "Yn"
     ],
     "lbl:latitude":63.652994,
     "lbl:longitude":-136.813577,
@@ -505,7 +511,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640677,
+    "wof:lastmodified":1565642886,
     "wof:name":"Yukon",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/95/85682095.geojson
+++ b/data/856/820/95/85682095.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "territory"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "YT"
+    ],
     "lbl:latitude":63.652994,
     "lbl:longitude":-136.813577,
     "mps:latitude":63.652994,
@@ -502,7 +505,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281736,
+    "wof:lastmodified":1565640677,
     "wof:name":"Yukon",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/13/85682113.geojson
+++ b/data/856/821/13/85682113.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SK"
+    ],
     "lbl:latitude":54.499056,
     "lbl:longitude":-105.950672,
     "mps:latitude":54.499056,
@@ -521,7 +524,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281782,
+    "wof:lastmodified":1565640695,
     "wof:name":"Saskatchewan",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/13/85682113.geojson
+++ b/data/856/821/13/85682113.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-105.892466,
     "iso:country":"CA",
     "iso:subdivision":"CA-SK",
+    "label:eng_x_preferred_abbreviation":[
+        "Sask."
+    ],
     "label:eng_x_preferred_longname":[
         "Saskatchewan Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "SK"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "Sask."
     ],
     "lbl:latitude":54.499056,
     "lbl:longitude":-105.950672,
@@ -524,7 +530,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640695,
+    "wof:lastmodified":1565642884,
     "wof:name":"Saskatchewan",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/17/85682117.geojson
+++ b/data/856/821/17/85682117.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "BC"
+    ],
     "lbl:latitude":54.790277,
     "lbl:longitude":-124.557003,
     "mps:latitude":54.790277,
@@ -545,7 +548,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281776,
+    "wof:lastmodified":1565640693,
     "wof:name":"British Columbia",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/17/85682117.geojson
+++ b/data/856/821/17/85682117.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-124.834255,
     "iso:country":"CA",
     "iso:subdivision":"CA-BC",
+    "label:eng_x_preferred_abbreviation":[
+        "B.C."
+    ],
     "label:eng_x_preferred_longname":[
         "British Columbia Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "BC"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "C.-B."
     ],
     "lbl:latitude":54.790277,
     "lbl:longitude":-124.557003,
@@ -548,7 +554,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640693,
+    "wof:lastmodified":1565642885,
     "wof:name":"British Columbia",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/23/85682123.geojson
+++ b/data/856/821/23/85682123.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NL"
+    ],
     "lbl:latitude":54.125069,
     "lbl:longitude":-61.783349,
     "mps:latitude":54.125069,
@@ -517,7 +520,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1563281780,
+    "wof:lastmodified":1565640694,
     "wof:name":"Newfoundland and Labrador",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/23/85682123.geojson
+++ b/data/856/821/23/85682123.geojson
@@ -14,6 +14,9 @@
     "geom:longitude":-60.344619,
     "iso:country":"CA",
     "iso:subdivision":"CA-NL",
+    "label:eng_x_preferred_abbreviation":[
+        "N.L."
+    ],
     "label:eng_x_preferred_longname":[
         "Newfoundland and Labrador Province"
     ],
@@ -22,6 +25,9 @@
     ],
     "label:eng_x_preferred_shortcode":[
         "NL"
+    ],
+    "label:fra_x_preferred_abbreviation":[
+        "T.-N.-L."
     ],
     "lbl:latitude":54.125069,
     "lbl:longitude":-61.783349,
@@ -520,7 +526,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1565640694,
+    "wof:lastmodified":1565642878,
     "wof:name":"Newfoundland and Labrador",
     "wof:parent_id":85633041,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1689.

- Adds a `label:eng_x_preferred_shortcode` property to any country, macroregion, region, or dependency record
- Removes any `wof:lang` property if `wof:lang_x_official` and `wof:lang_x_spoken` properties are present

Will not require PIP work, property edits only.

Script output:

```
whosonfirst-data-admin-ca
85633041,CA
85682095,YT
85682057,ON
85682067,NT
85682075,NS
85682081,PE
85682091,AB
85682065,NB
85682085,MB
85682105,NU
85682117,BC
85682123,NL
85682113,SK
136251273,QC
```