### PR TITLE
Round two of admin2 work in Alberta

### DIFF
--- a/data/110/893/634/7/1108936347.geojson
+++ b/data/110/893/634/7/1108936347.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936347,
             "region_id":85682091
         }
     ],
     "wof:id":1108936347,
-    "wof:lastmodified":1566519260,
+    "wof:lastmodified":1578005470,
     "wof:name":"Lacombe Park",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/634/9/1108936349.geojson
+++ b/data/110/893/634/9/1108936349.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936349,
             "region_id":85682091
         }
     ],
     "wof:id":1108936349,
-    "wof:lastmodified":1566519260,
+    "wof:lastmodified":1578005470,
     "wof:name":"Erin Ridge",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/635/1/1108936351.geojson
+++ b/data/110/893/635/1/1108936351.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936351,
             "region_id":85682091
         }
     ],
     "wof:id":1108936351,
-    "wof:lastmodified":1566519260,
+    "wof:lastmodified":1578005470,
     "wof:name":"Sturgeon Heights",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/635/3/1108936353.geojson
+++ b/data/110/893/635/3/1108936353.geojson
@@ -42,8 +42,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -55,13 +56,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936353,
             "region_id":85682091
         }
     ],
     "wof:id":1108936353,
-    "wof:lastmodified":1566519260,
+    "wof:lastmodified":1578005471,
     "wof:name":"Forest Lawn",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/635/5/1108936355.geojson
+++ b/data/110/893/635/5/1108936355.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936355,
             "region_id":85682091
         }
     ],
     "wof:id":1108936355,
-    "wof:lastmodified":1566519260,
+    "wof:lastmodified":1578005471,
     "wof:name":"Akinsdale",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/635/7/1108936357.geojson
+++ b/data/110/893/635/7/1108936357.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936357,
             "region_id":85682091
         }
     ],
     "wof:id":1108936357,
-    "wof:lastmodified":1566519260,
+    "wof:lastmodified":1578005471,
     "wof:name":"Pineview",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/636/1/1108936361.geojson
+++ b/data/110/893/636/1/1108936361.geojson
@@ -45,8 +45,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -58,13 +59,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936361,
             "region_id":85682091
         }
     ],
     "wof:id":1108936361,
-    "wof:lastmodified":1566519264,
+    "wof:lastmodified":1578005471,
     "wof:name":"Braeside",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/636/3/1108936363.geojson
+++ b/data/110/893/636/3/1108936363.geojson
@@ -66,8 +66,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -79,13 +80,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936363,
             "region_id":85682091
         }
     ],
     "wof:id":1108936363,
-    "wof:lastmodified":1566519264,
+    "wof:lastmodified":1578005472,
     "wof:name":"Kingswood",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/636/5/1108936365.geojson
+++ b/data/110/893/636/5/1108936365.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936365,
             "region_id":85682091
         }
     ],
     "wof:id":1108936365,
-    "wof:lastmodified":1566519264,
+    "wof:lastmodified":1578005472,
     "wof:name":"Oakmont",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/636/7/1108936367.geojson
+++ b/data/110/893/636/7/1108936367.geojson
@@ -114,8 +114,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -127,13 +128,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936367,
             "region_id":85682091
         }
     ],
     "wof:id":1108936367,
-    "wof:lastmodified":1566519264,
+    "wof:lastmodified":1578005470,
     "wof:name":"Riverside",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/636/9/1108936369.geojson
+++ b/data/110/893/636/9/1108936369.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936369,
             "region_id":85682091
         }
     ],
     "wof:id":1108936369,
-    "wof:lastmodified":1566519264,
+    "wof:lastmodified":1578005469,
     "wof:name":"Ville Giroux",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/637/1/1108936371.geojson
+++ b/data/110/893/637/1/1108936371.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936371,
             "region_id":85682091
         }
     ],
     "wof:id":1108936371,
-    "wof:lastmodified":1566519263,
+    "wof:lastmodified":1578005470,
     "wof:name":"Erin Ridge North",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/893/637/3/1108936373.geojson
+++ b/data/110/893/637/3/1108936373.geojson
@@ -36,8 +36,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -49,13 +50,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108936373,
             "region_id":85682091
         }
     ],
     "wof:id":1108936373,
-    "wof:lastmodified":1566519263,
+    "wof:lastmodified":1578005471,
     "wof:name":"Riel South",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/897/501/3/1108975013.geojson
+++ b/data/110/897/501/3/1108975013.geojson
@@ -29,8 +29,9 @@
     "src:geom":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -41,13 +42,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108975013,
             "region_id":85682091
         }
     ],
     "wof:id":1108975013,
-    "wof:lastmodified":1566519312,
+    "wof:lastmodified":1578005469,
     "wof:name":"Jensen Lakes",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/897/501/5/1108975015.geojson
+++ b/data/110/897/501/5/1108975015.geojson
@@ -47,8 +47,9 @@
     "src:geom":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -59,13 +60,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108975015,
             "region_id":85682091
         }
     ],
     "wof:id":1108975015,
-    "wof:lastmodified":1566519312,
+    "wof:lastmodified":1578005467,
     "wof:name":"Elysian Fields",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/897/501/7/1108975017.geojson
+++ b/data/110/897/501/7/1108975017.geojson
@@ -44,8 +44,9 @@
     "src:geom":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -56,13 +57,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108975017,
             "region_id":85682091
         }
     ],
     "wof:id":1108975017,
-    "wof:lastmodified":1566519312,
+    "wof:lastmodified":1578005469,
     "wof:name":"Avenir",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/897/501/9/1108975019.geojson
+++ b/data/110/897/501/9/1108975019.geojson
@@ -29,8 +29,9 @@
     "src:geom":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -41,13 +42,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108975019,
             "region_id":85682091
         }
     ],
     "wof:id":1108975019,
-    "wof:lastmodified":1566519312,
+    "wof:lastmodified":1578005472,
     "wof:name":"City Annex",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/897/502/1/1108975021.geojson
+++ b/data/110/897/502/1/1108975021.geojson
@@ -29,8 +29,9 @@
     "src:geom":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -41,13 +42,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108975021,
             "region_id":85682091
         }
     ],
     "wof:id":1108975021,
-    "wof:lastmodified":1566519300,
+    "wof:lastmodified":1578005472,
     "wof:name":"City Annex North",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/110/897/502/5/1108975025.geojson
+++ b/data/110/897/502/5/1108975025.geojson
@@ -29,8 +29,9 @@
     "src:geom":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -41,13 +42,14 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":1108975025,
             "region_id":85682091
         }
     ],
     "wof:id":1108975025,
-    "wof:lastmodified":1566519301,
+    "wof:lastmodified":1578005473,
     "wof:name":"City Annex West",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/119/314/129/9/1193141299.geojson
+++ b/data/119/314/129/9/1193141299.geojson
@@ -195,7 +195,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -207,14 +208,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":1193141299,
             "region_id":85682091
         }
     ],
     "wof:id":1193141299,
-    "wof:lastmodified":1566519213,
+    "wof:lastmodified":1578005465,
     "wof:name":"Sturgeon",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/122/676/511/3/1226765113.geojson
+++ b/data/122/676/511/3/1226765113.geojson
@@ -33,7 +33,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -46,14 +47,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":1226765113,
             "region_id":85682091
         }
     ],
     "wof:id":1226765113,
-    "wof:lastmodified":1566520601,
+    "wof:lastmodified":1578006338,
     "wof:name":"Cambria",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/126/029/910/3/1260299103.geojson
+++ b/data/126/029/910/3/1260299103.geojson
@@ -33,7 +33,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -45,14 +46,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":1260299103,
             "region_id":85682091
         }
     ],
     "wof:id":1260299103,
-    "wof:lastmodified":1566519237,
+    "wof:lastmodified":1578006339,
     "wof:name":"Western Monarch",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/127/644/641/9/1276446419.geojson
+++ b/data/127/644/641/9/1276446419.geojson
@@ -111,7 +111,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -123,14 +124,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":1276446419,
             "region_id":85682091
         }
     ],
     "wof:id":1276446419,
-    "wof:lastmodified":1566519098,
+    "wof:lastmodified":1578005465,
     "wof:name":"Campbell",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/127/707/843/7/1277078437.geojson
+++ b/data/127/707/843/7/1277078437.geojson
@@ -33,7 +33,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -45,14 +46,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":1277078437,
             "region_id":85682091
         }
     ],
     "wof:id":1277078437,
-    "wof:lastmodified":1566519091,
+    "wof:lastmodified":1578006339,
     "wof:name":"Eladesor",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/127/709/186/1/1277091861.geojson
+++ b/data/127/709/186/1/1277091861.geojson
@@ -33,7 +33,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -45,14 +46,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":1277091861,
             "region_id":85682091
         }
     ],
     "wof:id":1277091861,
-    "wof:lastmodified":1566519090,
+    "wof:lastmodified":1578006339,
     "wof:name":"Kneehill",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/129/331/032/7/1293310327.geojson
+++ b/data/129/331/032/7/1293310327.geojson
@@ -33,7 +33,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -46,14 +47,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":1293310327,
             "region_id":85682091
         }
     ],
     "wof:id":1293310327,
-    "wof:lastmodified":1566519030,
+    "wof:lastmodified":1578006339,
     "wof:name":"Newcastle Mine",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/132/674/790/3/1326747903.geojson
+++ b/data/132/674/790/3/1326747903.geojson
@@ -60,7 +60,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -72,14 +73,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":1326747903,
             "region_id":85682091
         }
     ],
     "wof:id":1326747903,
-    "wof:lastmodified":1566518829,
+    "wof:lastmodified":1578005465,
     "wof:name":"Woodlands",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/132/744/559/1/1327445591.geojson
+++ b/data/132/744/559/1/1327445591.geojson
@@ -33,7 +33,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -46,14 +47,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":1327445591,
             "region_id":85682091
         }
     ],
     "wof:id":1327445591,
-    "wof:lastmodified":1566518858,
+    "wof:lastmodified":1578006338,
     "wof:name":"Wayne",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/134/357/893/3/1343578933.geojson
+++ b/data/134/357/893/3/1343578933.geojson
@@ -66,7 +66,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,14 +79,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":1343578933,
             "region_id":85682091
         }
     ],
     "wof:id":1343578933,
-    "wof:lastmodified":1566518890,
+    "wof:lastmodified":1578006338,
     "wof:name":"Willow Creek",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],

--- a/data/151/179/978/9/1511799789.geojson
+++ b/data/151/179/978/9/1511799789.geojson
@@ -12,8 +12,6 @@
     "iso:country":"CA",
     "lbl:latitude":51.056508,
     "lbl:longitude":-114.033822,
-    "lbl:max_zoom":13.0,
-    "lbl:min_zoom":6.0,
     "mps:latitude":51.056508,
     "mps:longitude":-114.033822,
     "mz:hierarchy_label":0,
@@ -402,7 +400,7 @@
         }
     ],
     "wof:id":1511799789,
-    "wof:lastmodified":1577998193,
+    "wof:lastmodified":1578006254,
     "wof:name":"Calgary",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/151/179/979/1/1511799791.geojson
+++ b/data/151/179/979/1/1511799791.geojson
@@ -12,8 +12,6 @@
     "iso:country":"CA",
     "lbl:latitude":53.546218,
     "lbl:longitude":-113.490371,
-    "lbl:max_zoom":18.0,
-    "lbl:min_zoom":13.5,
     "mps:latitude":36.982196,
     "mps:longitude":-85.613637,
     "mz:hierarchy_label":0,
@@ -417,7 +415,7 @@
         }
     ],
     "wof:id":1511799791,
-    "wof:lastmodified":1577998027,
+    "wof:lastmodified":1578006403,
     "wof:name":"Edmonton",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/151/179/979/3/1511799793.geojson
+++ b/data/151/179/979/3/1511799793.geojson
@@ -12,8 +12,6 @@
     "iso:country":"CA",
     "lbl:latitude":51.416779,
     "lbl:longitude":-112.645231,
-    "lbl:max_zoom":18.0,
-    "lbl:min_zoom":13.5,
     "mps:latitude":51.416779,
     "mps:longitude":-112.645231,
     "mz:hierarchy_label":0,
@@ -99,15 +97,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
-            "locality_id":1511799793,
+            "county_id":1511799793,
             "region_id":85682091
         }
     ],
     "wof:id":1511799793,
-    "wof:lastmodified":1577997629,
+    "wof:lastmodified":1578006341,
     "wof:name":"Drumheller",
     "wof:parent_id":85682091,
-    "wof:placetype":"locality",
+    "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:statistical_gore":1,
     "wof:superseded_by":[],

--- a/data/151/179/979/7/1511799797.geojson
+++ b/data/151/179/979/7/1511799797.geojson
@@ -1,10 +1,7 @@
 {
-  "id": 890458223,
+  "id": 1511799797,
   "type": "Feature",
   "properties": {
-    "can-abog:geocode":"0117",
-    "can-abog:geoname":"CITY OF FORT SASKATCHEWAN",
-    "can-abog:pid":30135,
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006573,
@@ -12,23 +9,16 @@
     "geom:bbox":"-113.29355196,53.6717279173,-113.124391003,53.7743928396",
     "geom:latitude":53.717749,
     "geom:longitude":-113.188613,
-    "gn:country":"CA",
-    "gn:fcode":"PPL",
-    "gn:population":14957,
-    "gp:adm0":23424775,
     "iso:country":"CA",
     "label:eng_x_preferred_longname":[
         "City of Fort Saskatchewan"
     ],
     "lbl:latitude":53.716832,
     "lbl:longitude":-113.189925,
-    "lbl:max_zoom":15.0,
-    "lbl:min_zoom":10.5,
     "mps:latitude":53.716832,
     "mps:longitude":-113.189925,
-    "mz:hierarchy_label":1,
+    "mz:hierarchy_label":0,
     "mz:is_current":1,
-    "mz:min_zoom":10.0,
     "name:ara_x_preferred":[
         "\u0641\u0648\u0631\u062a \u0633\u0627\u0633\u0643\u0627\u062a\u0634\u0648\u0627\u0646"
     ],
@@ -173,29 +163,14 @@
     "name:zho_x_preferred":[
         "\u8428\u65af\u5580\u5f7b\u6e29\u5821"
     ],
-    "qs:name":"Fort Saskatchewan",
-    "qs:name_adm0":"Canada",
-    "qs:name_adm1":"Alberta",
-    "qs:photos":282,
-    "qs:photos_1k":57,
-    "qs:photos_9k":2,
-    "qs:photos_9r":5,
-    "qs:photos_all":373,
-    "qs:photos_sr":5,
-    "qs:placetype":"Town",
-    "qs:pop_sr":"7",
     "src:geom":"can-abog",
-    "src:geom_alt":[
-        "unknown"
-    ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "wd:wordcount":3322,
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091,
-        1511799797
+        85682091
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -206,7 +181,7 @@
         "wk:page":"Fort Saskatchewan"
     },
     "wof:coterminous":[
-        1511799797
+        890458223
     ],
     "wof:country":"CA",
     "wof:created":1469053197,
@@ -216,19 +191,18 @@
             "continent_id":102191575,
             "country_id":85633041,
             "county_id":1511799797,
-            "locality_id":890458223,
             "region_id":85682091
         }
     ],
-    "wof:id":890458223,
-    "wof:lastmodified":1578005412,
+    "wof:id":1511799797,
+    "wof:lastmodified":1578005442,
     "wof:name":"Fort Saskatchewan",
-    "wof:parent_id":1511799797,
-    "wof:placetype":"locality",
-    "wof:placetype_local":"city",
+    "wof:parent_id":85682091,
+    "wof:placetype":"county",
     "wof:population":14957,
     "wof:population_rank":6,
     "wof:repo":"whosonfirst-data-admin-ca",
+    "wof:statistical_gore":1,
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]

--- a/data/151/179/979/9/1511799799.geojson
+++ b/data/151/179/979/9/1511799799.geojson
@@ -1,11 +1,7 @@
 {
-  "id": 890458621,
+  "id": 1511799799,
   "type": "Feature",
   "properties": {
-    "can-abog:CITY_ID":15,
-    "can-abog:GEOCODE":"0292",
-    "can-abog:GEONAME":"CITY OF ST. ALBERT",
-    "can-abog:PID":30143,
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006759,
@@ -13,20 +9,13 @@
     "geom:bbox":"-113.707606627,53.5995952756,-113.565622056,53.6826602001",
     "geom:latitude":53.6407,
     "geom:longitude":-113.63844,
-    "gn:country":"CA",
-    "gn:fcode":"PPL",
-    "gn:population":57719,
-    "gp:adm0":23424775,
     "iso:country":"CA",
     "lbl:latitude":53.63344,
     "lbl:longitude":-113.63533,
-    "lbl:max_zoom":14.0,
-    "lbl:min_zoom":9.5,
     "mps:latitude":53.639748,
     "mps:longitude":-113.633609,
-    "mz:hierarchy_label":1,
+    "mz:hierarchy_label":0,
     "mz:is_current":1,
-    "mz:min_zoom":8.0,
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0623\u0644\u0628\u0631\u062a"
     ],
@@ -174,30 +163,15 @@
     "name:zho_x_preferred":[
         "\u5723\u827e\u4f2f\u7279"
     ],
-    "qs:name":"St. Albert",
-    "qs:name_adm0":"Canada",
-    "qs:name_adm1":"Alberta",
-    "qs:photos":1008,
-    "qs:photos_1k":204,
-    "qs:photos_9k":11,
-    "qs:photos_9r":10,
-    "qs:photos_all":2412,
-    "qs:photos_sr":11,
-    "qs:placetype":"Town",
-    "qs:pop_sr":"8",
     "reversegeo:latitude":53.639748,
     "reversegeo:longitude":-113.633609,
     "src:geom":"can-abog",
-    "src:geom_alt":[
-        "unknown"
-    ],
     "src:population":"geonames",
     "wd:wordcount":326,
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091,
-        1511799799
+        85682091
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -208,7 +182,7 @@
         "wk:page":"Saint Albert"
     },
     "wof:coterminous":[
-        1511799799
+        890458621
     ],
     "wof:country":"CA",
     "wof:created":1469053228,
@@ -218,18 +192,18 @@
             "continent_id":102191575,
             "country_id":85633041,
             "county_id":1511799799,
-            "locality_id":890458621,
             "region_id":85682091
         }
     ],
-    "wof:id":890458621,
-    "wof:lastmodified":1578005464,
+    "wof:id":1511799799,
+    "wof:lastmodified":1578005473,
     "wof:name":"St. Albert",
-    "wof:parent_id":1511799799,
-    "wof:placetype":"locality",
+    "wof:parent_id":85682091,
+    "wof:placetype":"county",
     "wof:population":57719,
     "wof:population_rank":8,
     "wof:repo":"whosonfirst-data-admin-ca",
+    "wof:statistical_gore":1,
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]

--- a/data/858/945/43/85894543.geojson
+++ b/data/858/945/43/85894543.geojson
@@ -42,8 +42,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -57,6 +58,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894543,
             "region_id":85682091
@@ -66,7 +68,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519019,
+    "wof:lastmodified":1578005467,
     "wof:name":"Campbell Business Park",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/45/85894545.geojson
+++ b/data/858/945/45/85894545.geojson
@@ -43,8 +43,9 @@
     "wd:wordcount":306,
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -58,6 +59,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894545,
             "region_id":85682091
@@ -67,7 +69,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519019,
+    "wof:lastmodified":1578005473,
     "wof:name":"Deer Ridge",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/47/85894547.geojson
+++ b/data/858/945/47/85894547.geojson
@@ -42,8 +42,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -57,6 +58,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894547,
             "region_id":85682091
@@ -66,7 +68,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519020,
+    "wof:lastmodified":1578005468,
     "wof:name":"Downtown Saint Albert",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/49/85894549.geojson
+++ b/data/858/945/49/85894549.geojson
@@ -76,8 +76,9 @@
     "wd:wordcount":154,
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -91,6 +92,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894549,
             "region_id":85682091
@@ -100,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519020,
+    "wof:lastmodified":1578005468,
     "wof:name":"Grandin",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/53/85894553.geojson
+++ b/data/858/945/53/85894553.geojson
@@ -39,8 +39,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -54,6 +55,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894553,
             "region_id":85682091
@@ -63,7 +65,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519019,
+    "wof:lastmodified":1578005468,
     "wof:name":"Heritage Lakes",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/55/85894555.geojson
+++ b/data/858/945/55/85894555.geojson
@@ -42,8 +42,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -58,6 +59,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894555,
             "region_id":85682091
@@ -67,7 +69,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519020,
+    "wof:lastmodified":1578005473,
     "wof:name":"Inglewood",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/57/85894557.geojson
+++ b/data/858/945/57/85894557.geojson
@@ -96,8 +96,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -111,6 +112,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894557,
             "region_id":85682091
@@ -120,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519019,
+    "wof:lastmodified":1578005469,
     "wof:name":"Mission",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/59/85894559.geojson
+++ b/data/858/945/59/85894559.geojson
@@ -45,8 +45,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -60,6 +61,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894559,
             "region_id":85682091
@@ -69,7 +71,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519019,
+    "wof:lastmodified":1578005467,
     "wof:name":"North Ridge",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/63/85894563.geojson
+++ b/data/858/945/63/85894563.geojson
@@ -43,8 +43,9 @@
     "wd:wordcount":82,
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -58,6 +59,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894563,
             "region_id":85682091
@@ -67,7 +69,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519020,
+    "wof:lastmodified":1578005468,
     "wof:name":"Riel Business Park",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/65/85894565.geojson
+++ b/data/858/945/65/85894565.geojson
@@ -86,8 +86,9 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191575,
-        890458621,
         85633041,
+        890458621,
+        1511799799,
         85682091
     ],
     "wof:breaches":[],
@@ -102,6 +103,7 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799799,
             "locality_id":890458621,
             "neighbourhood_id":85894565,
             "region_id":85682091
@@ -111,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519019,
+    "wof:lastmodified":1578005469,
     "wof:name":"Woodlands",
     "wof:parent_id":890458621,
     "wof:placetype":"neighbourhood",

--- a/data/858/945/67/85894567.geojson
+++ b/data/858/945/67/85894567.geojson
@@ -201,6 +201,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
+        890458223,
+        1511799797,
         85682091
     ],
     "wof:breaches":[],
@@ -215,7 +217,8 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
-            "locality_id":-1,
+            "county_id":1511799797,
+            "locality_id":890458223,
             "neighbourhood_id":85894567,
             "region_id":85682091
         }
@@ -224,9 +227,9 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519019,
+    "wof:lastmodified":1578005441,
     "wof:name":"Downtown Fort Saskatchewan",
-    "wof:parent_id":-1,
+    "wof:parent_id":890458223,
     "wof:placetype":"neighbourhood",
     "wof:population_rank":0,
     "wof:repo":"whosonfirst-data-admin-ca",

--- a/data/858/945/71/85894571.geojson
+++ b/data/858/945/71/85894571.geojson
@@ -63,6 +63,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
+        890458223,
+        1511799797,
         85682091
     ],
     "wof:breaches":[],
@@ -76,7 +78,8 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
-            "locality_id":-1,
+            "county_id":1511799797,
+            "locality_id":890458223,
             "neighbourhood_id":85894571,
             "region_id":85682091
         }
@@ -85,9 +88,9 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566519020,
+    "wof:lastmodified":1578005441,
     "wof:name":"Pineview",
-    "wof:parent_id":-1,
+    "wof:parent_id":890458223,
     "wof:placetype":"neighbourhood",
     "wof:population_rank":0,
     "wof:repo":"whosonfirst-data-admin-ca",

--- a/data/890/457/605/890457605.geojson
+++ b/data/890/457/605/890457605.geojson
@@ -39,7 +39,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,14 +57,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":890457605,
             "region_id":85682091
         }
     ],
     "wof:id":890457605,
-    "wof:lastmodified":1566520217,
+    "wof:lastmodified":1578006339,
     "wof:name":"East Coulee",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:population":0,
     "wof:repo":"whosonfirst-data-admin-ca",

--- a/data/890/457/703/890457703.geojson
+++ b/data/890/457/703/890457703.geojson
@@ -35,7 +35,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -51,14 +52,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":890457703,
             "region_id":85682091
         }
     ],
     "wof:id":890457703,
-    "wof:lastmodified":1566520235,
+    "wof:lastmodified":1578006338,
     "wof:name":"Nacmine",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:population_rank":0,
     "wof:repo":"whosonfirst-data-admin-ca",

--- a/data/890/457/853/890457853.geojson
+++ b/data/890/457/853/890457853.geojson
@@ -42,7 +42,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -59,14 +60,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":890457853,
             "region_id":85682091
         }
     ],
     "wof:id":890457853,
-    "wof:lastmodified":1566520248,
+    "wof:lastmodified":1578006339,
     "wof:name":"Rosedale",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:population":0,
     "wof:repo":"whosonfirst-data-admin-ca",

--- a/data/890/458/269/890458269.geojson
+++ b/data/890/458/269/890458269.geojson
@@ -104,7 +104,8 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091
+        85682091,
+        1511799793
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -124,14 +125,15 @@
         {
             "continent_id":102191575,
             "country_id":85633041,
+            "county_id":1511799793,
             "locality_id":890458269,
             "region_id":85682091
         }
     ],
     "wof:id":890458269,
-    "wof:lastmodified":1577993858,
+    "wof:lastmodified":1578006340,
     "wof:name":"Drumheller",
-    "wof:parent_id":85682091,
+    "wof:parent_id":1511799793,
     "wof:placetype":"locality",
     "wof:placetype_local":"town",
     "wof:repo":"whosonfirst-data-admin-ca",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1765.

Follow up to #13 

This PR adds additional admin2 coverage in Alberta and PIPs the descendant records of these new records. Workflows are similar to what was done in #13.

Includes PIP work and validation, can merge as-is.