### PR TITLE
Fix hierarchies, geometries, and other properties for localities

### DIFF
--- a/data/112/594/694/7/1125946947-alt-qs_pg.geojson
+++ b/data/112/594/694/7/1125946947-alt-qs_pg.geojson
@@ -1,0 +1,18 @@
+{
+  "id": 1125946947,
+  "type": "Feature",
+  "properties": {
+    "src:geom":"qs_pg",
+    "src:alt_label":"qs_pg",
+    "wof:geomhash":"848bad7197876e41fc9528d3cb2f6f79",
+    "wof:id":1125946947,
+    "wof:repo":"whosonfirst-data-admin-ca"
+},
+  "bbox": [
+    -79.04957,
+    43.16682,
+    -79.04957,
+    43.16682
+],
+  "geometry": {"coordinates":[-79.04957,43.16682],"type":"Point"}
+}

--- a/data/112/594/694/7/1125946947.geojson
+++ b/data/112/594/694/7/1125946947.geojson
@@ -6,16 +6,16 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-79.04957,43.16682,-79.04957,43.16682",
-    "geom:latitude":43.16682,
-    "geom:longitude":-79.04957,
+    "geom:bbox":"-79.057006,43.168324,-79.057006,43.168324",
+    "geom:latitude":43.168324,
+    "geom:longitude":-79.057006,
     "gn:country":"CA",
     "gn:fcode":"PPL",
     "gn:population":0,
     "iso:country":"CA",
     "lbl:bbox":"-79.06957,43.14682,-79.02957,43.18682",
-    "lbl:latitude":43.16682,
-    "lbl:longitude":-79.04957,
+    "lbl:latitude":43.168324,
+    "lbl:longitude":-79.057006,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
@@ -78,18 +78,20 @@
     "qs_pg:qs_pg_placetype_gp":"Town",
     "qs_pg:woe_adm0":23424775,
     "qs_pg:woe_id":1291,
-    "src:geom":"qs_pg",
+    "src:geom":"whosonfirst",
+    "src:geom_alt":[
+        "qs_pg"
+    ],
     "src:lbl_centroid":"qs_pg",
     "woe:adm0_id":23424775,
     "woe:name_adm0":"Canada",
     "woe:name_adm1":"Ontario",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522733,
-        85633793,
-        102081767
+        85633041,
+        890456991,
+        85682057
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,21 +102,20 @@
     },
     "wof:country":"CA",
     "wof:created":1497297319,
-    "wof:geomhash":"848bad7197876e41fc9528d3cb2f6f79",
+    "wof:geomhash":"544b4914d191d4cc288e15ae025bbf50",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
-            "country_id":85633793,
-            "county_id":102081767,
-            "localadmin_id":404522733,
+            "country_id":85633041,
+            "county_id":890456991,
             "locality_id":1125946947,
-            "region_id":85688543
+            "region_id":85682057
         }
     ],
     "wof:id":1125946947,
-    "wof:lastmodified":1566520255,
+    "wof:lastmodified":1599870568,
     "wof:name":"Queenston",
-    "wof:parent_id":404522733,
+    "wof:parent_id":890456991,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],
@@ -122,10 +123,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -79.04957,
-    43.16682,
-    -79.04957,
-    43.16682
+    -79.057006,
+    43.168324,
+    -79.057006,
+    43.168324
 ],
-  "geometry": {"coordinates":[-79.04957,43.16682],"type":"Point"}
+  "geometry": {"coordinates":[-79.057006,43.168324],"type":"Point"}
 }

--- a/data/112/600/233/5/1126002335-alt-qs_pg.geojson
+++ b/data/112/600/233/5/1126002335-alt-qs_pg.geojson
@@ -1,0 +1,18 @@
+{
+  "id": 1126002335,
+  "type": "Feature",
+  "properties": {
+    "src:geom":"qs_pg",
+    "src:alt_label":"qs_pg",
+    "wof:geomhash":"decaaf332c7473d2a606e8bbfc5477fd",
+    "wof:id":1126002335,
+    "wof:repo":"whosonfirst-data-admin-ca"
+},
+  "bbox": [
+    -116.180419,
+    49.000492,
+    -116.180419,
+    49.000492
+],
+  "geometry": {"coordinates":[-116.180419,49.000492],"type":"Point"}
+}

--- a/data/112/600/233/5/1126002335.geojson
+++ b/data/112/600/233/5/1126002335.geojson
@@ -6,14 +6,14 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-116.180419,49.000492,-116.180419,49.000492",
-    "geom:latitude":49.000492,
-    "geom:longitude":-116.180419,
+    "geom:bbox":"-116.180147,49.005666,-116.180147,49.005666",
+    "geom:latitude":49.005666,
+    "geom:longitude":-116.180147,
     "gn:country":"CA",
     "iso:country":"CA",
     "lbl:bbox":"-116.200419,48.980492,-116.160419,49.020492",
-    "lbl:latitude":49.000492,
-    "lbl:longitude":-116.180419,
+    "lbl:latitude":49.005666,
+    "lbl:longitude":-116.180147,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
@@ -43,7 +43,10 @@
     "qs_pg:qs_pg_placetype_gp":"Town",
     "qs_pg:woe_adm0":23424775,
     "qs_pg:woe_id":23405782,
-    "src:geom":"qs_pg",
+    "src:geom":"whosonfirst",
+    "src:geom_alt":[
+        "qs_pg"
+    ],
     "src:lbl_centroid":"qs_pg",
     "woe:adm0_id":23424775,
     "woe:name_adm0":"Canada",
@@ -51,12 +54,9 @@
     "woe:placetype":"Town",
     "wof:belongsto":[
         102191575,
-        85633793,
-        85688657,
-        102085203,
         85633041,
-        85682117,
-        890458089
+        890458089,
+        85682117
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,15 +66,8 @@
     },
     "wof:country":"CA",
     "wof:created":1497299726,
-    "wof:geomhash":"decaaf332c7473d2a606e8bbfc5477fd",
+    "wof:geomhash":"820c2608e9008e7b0b3f1149348ff680",
     "wof:hierarchy":[
-        {
-            "continent_id":102191575,
-            "country_id":85633793,
-            "county_id":102085203,
-            "locality_id":1126002335,
-            "region_id":85688657
-        },
         {
             "continent_id":102191575,
             "country_id":85633041,
@@ -84,9 +77,9 @@
         }
     ],
     "wof:id":1126002335,
-    "wof:lastmodified":1566520342,
+    "wof:lastmodified":1599869873,
     "wof:name":"Kingsgate",
-    "wof:parent_id":-4,
+    "wof:parent_id":890458089,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],
@@ -94,10 +87,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -116.180419,
-    49.000492,
-    -116.180419,
-    49.000492
+    -116.180147,
+    49.005666,
+    -116.180147,
+    49.005666
 ],
-  "geometry": {"coordinates":[-116.180419,49.000492],"type":"Point"}
+  "geometry": {"coordinates":[-116.18014700000001,49.005666],"type":"Point"}
 }

--- a/data/124/287/706/3/1242877063-alt-geonames.geojson
+++ b/data/124/287/706/3/1242877063-alt-geonames.geojson
@@ -1,0 +1,18 @@
+{
+  "id": 1242877063,
+  "type": "Feature",
+  "properties": {
+    "src:geom":"geonames",
+    "src:alt_label":"geonames",
+    "wof:geomhash":"38b40091f9d96fc0a50ddfa67696c655",
+    "wof:id":1242877063,
+    "wof:repo":"whosonfirst-data-admin-ca"
+},
+  "bbox": [
+    -122.26667,
+    49.0,
+    -122.26667,
+    49.0
+],
+  "geometry": {"coordinates":[-122.26667,49.0],"type":"Point"}
+}

--- a/data/124/287/706/3/1242877063.geojson
+++ b/data/124/287/706/3/1242877063.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-122.26667,49.0,-122.26667,49.0",
-    "geom:latitude":49.0,
-    "geom:longitude":-122.26667,
+    "geom:bbox":"-122.268006,49.005358,-122.268006,49.005358",
+    "geom:latitude":49.005358,
+    "geom:longitude":-122.268006,
     "gn:admin1_code":"2",
     "gn:admin2_code":"5909.0",
     "gn:asciiname":"Huntingdon",
@@ -25,10 +25,12 @@
     "gn:timezone":"America/Los_Angeles",
     "iso:country":"CA",
     "lbl:bbox":"-122.28667,48.98,-122.24667,49.02",
+    "lbl:latitude":49.005358,
+    "lbl:longitude":-122.268006,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ang_x_preferred":[
         "Huntand\u016bn"
@@ -138,32 +140,35 @@
     "name:zho_x_preferred":[
         "\u4ea8\u5ef7\u767b"
     ],
-    "src:geom":"geonames",
+    "src:geom":"whosonfirst",
+    "src:geom_alt":[
+        "geonames"
+    ],
     "wof:belongsto":[
         102191575,
-        85633793,
-        85688623,
-        102085363
+        85633041,
+        890458867,
+        85682117
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":5978686
     },
     "wof:country":"CA",
-    "wof:geomhash":"38b40091f9d96fc0a50ddfa67696c655",
+    "wof:geomhash":"c114324f5f9ae9320de8bf80d1b68d95",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
-            "country_id":85633793,
-            "county_id":102085363,
+            "country_id":85633041,
+            "county_id":890458867,
             "locality_id":1242877063,
-            "region_id":85688623
+            "region_id":85682117
         }
     ],
     "wof:id":1242877063,
-    "wof:lastmodified":1566520474,
+    "wof:lastmodified":1599870572,
     "wof:name":"Huntingdon",
-    "wof:parent_id":102085363,
+    "wof:parent_id":890458867,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ca",
     "wof:superseded_by":[],
@@ -171,10 +176,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -122.26667,
-    49.0,
-    -122.26667,
-    49.0
+    -122.268006,
+    49.005358,
+    -122.268006,
+    49.005358
 ],
-  "geometry": {"coordinates":[-122.26667,49.0],"type":"Point"}
+  "geometry": {"coordinates":[-122.268006,49.005358],"type":"Point"}
 }


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1832.

This PR updates three locality points on the US/CA border. These records are correctly maintained in the `CA` admin repo, but have hierarchy and parent_id references to the US. For these records, this PR:

- Moves the existing geometry to an alt
- Updates `src:geom` and `src:geom_alt` properties
- Updates `lbl:*` properties
- Updates the `wof:hierarchy` and `wof:parent_id` property values to point to CA, rather than the US

No PIP work necessary since these records are points and don't have descendants. The hierarchies have been manually adjusted/checked. Can merge once approved.