### PR TITLE
New Brigus Junction locality

### DIFF
--- a/data/172/920/948/9/1729209489.geojson
+++ b/data/172/920/948/9/1729209489.geojson
@@ -1,0 +1,59 @@
+{
+  "id": 1729209489,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-53.300342,47.387323,-53.300342,47.387323",
+    "geom:latitude":47.387323,
+    "geom:longitude":-53.300342,
+    "iso:country":"CA",
+    "lbl:bbox":"-53.320342,47.367323,-53.280342,47.407323",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:min_zoom":12.0,
+    "src:geom":"whosonfirst",
+    "wof:belongsto":[
+        102191575,
+        85633041,
+        1158869009,
+        85682123
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5908890,
+        "wk:page":"Brigus_Junction"
+    },
+    "wof:country":"CA",
+    "wof:geomhash":"0df84b771616db058ddc0f51df74be0a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191575,
+            "country_id":85633041,
+            "county_id":1158869009,
+            "locality_id":1729209489,
+            "region_id":85682123
+        }
+    ],
+    "wof:id":1729209489,
+    "wof:lastmodified":1599872949,
+    "wof:name":"Brigus Junction",
+    "wof:parent_id":1158869009,
+    "wof:placetype":"locality",
+    "wof:repo":"whosonfirst-data-admin-ca",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -53.300342,
+    47.387323,
+    -53.300342,
+    47.387323
+],
+  "geometry": {"coordinates":[-53.300342,47.387323],"type":"Point"}
+}

--- a/data/172/920/948/9/1729209489.geojson
+++ b/data/172/920/948/9/1729209489.geojson
@@ -16,6 +16,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Brigus Junction"
+    ],
     "src:geom":"whosonfirst",
     "wof:belongsto":[
         102191575,
@@ -40,7 +43,7 @@
         }
     ],
     "wof:id":1729209489,
-    "wof:lastmodified":1599872949,
+    "wof:lastmodified":1599873020,
     "wof:name":"Brigus Junction",
     "wof:parent_id":1158869009,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1744

WOF is missing a locality record for the settlement of Brigus Junction, CA. This PR adds a record for it, including any PIP work.