### PR TITLE
Update properties of megacities

### DIFF
--- a/data/101/735/835/101735835.geojson
+++ b/data/101/735/835/101735835.geojson
@@ -698,6 +698,7 @@
         "gn:id":6167865,
         "gp:id":4118,
         "loc:id":"n79079328",
+        "ne:id":1159151557,
         "nyt:id":"N59025796970344002461",
         "qs_pg:id":767067,
         "wd:id":"Q172",
@@ -725,7 +726,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1607571250,
+    "wof:lastmodified":1608688190,
     "wof:megacity":1,
     "wof:name":"Toronto",
     "wof:parent_id":890457465,

--- a/data/101/735/873/101735873.geojson
+++ b/data/101/735/873/101735873.geojson
@@ -19,7 +19,7 @@
     "mps:longitude":-75.783876,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":5.0,
+    "mz:min_zoom":3.0,
     "name:ace_x_preferred":[
         "Ottawa"
     ],
@@ -597,6 +597,7 @@
         "gn:id":6094817,
         "gp:id":3369,
         "loc:id":"n79063073",
+        "ne:id":1159151059,
         "nyt:id":"31759159557039305561",
         "qs_pg:id":274725,
         "wd:id":"Q1930",
@@ -624,7 +625,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1607571220,
+    "wof:lastmodified":1608688178,
     "wof:megacity":1,
     "wof:name":"Ottawa",
     "wof:parent_id":890458681,

--- a/data/101/736/545/101736545.geojson
+++ b/data/101/736/545/101736545.geojson
@@ -736,6 +736,7 @@
         "gn:id":6077243,
         "gp:id":3534,
         "loc:id":"n80132975",
+        "ne:id":1159151457,
         "nyt:id":"N59179828586486930801",
         "qs_pg:id":239659,
         "tgn:id":7013051,
@@ -764,7 +765,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1607723866,
+    "wof:lastmodified":1608688187,
     "wof:megacity":1,
     "wof:name":"Montreal",
     "wof:parent_id":890458661,

--- a/data/101/741/075/101741075.geojson
+++ b/data/101/741/075/101741075.geojson
@@ -621,6 +621,7 @@
         "fb:id":"en.vancouver_british_columbia",
         "gn:id":6173331,
         "gp:id":9807,
+        "ne:id":1159151555,
         "nyt:id":9223372036854775807,
         "qs_pg:id":767793,
         "wd:id":"Q24639",
@@ -642,7 +643,7 @@
         }
     ],
     "wof:id":101741075,
-    "wof:lastmodified":1587428290,
+    "wof:lastmodified":1608688190,
     "wof:megacity":1,
     "wof:name":"Vancouver",
     "wof:parent_id":890457467,

--- a/data/890/458/485/890458485.geojson
+++ b/data/890/458/485/890458485.geojson
@@ -546,6 +546,7 @@
     "wof:concordances":{
         "gn:id":5946768,
         "gp:id":8676,
+        "ne:id":1159151455,
         "qs_pg:id":355729,
         "wd:id":"Q2096",
         "wk:page":"Edmonton"
@@ -572,7 +573,8 @@
         }
     ],
     "wof:id":890458485,
-    "wof:lastmodified":1607462653,
+    "wof:lastmodified":1608688186,
+    "wof:megacity":1,
     "wof:name":"Edmonton",
     "wof:parent_id":1511799791,
     "wof:placetype":"locality",

--- a/data/890/458/845/890458845.geojson
+++ b/data/890/458/845/890458845.geojson
@@ -22,7 +22,7 @@
     "mps:longitude":-114.033822,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":5.0,
+    "mz:min_zoom":4.0,
     "name:afr_x_preferred":[
         "Calgary"
     ],
@@ -488,13 +488,14 @@
     "wof:belongsto":[
         102191575,
         85633041,
-        85682091,
-        1511799789
+        1511799789,
+        85682091
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":5913490,
         "gp:id":8775,
+        "ne:id":1159151035,
         "qs_pg:id":239666,
         "wd:id":"Q36312",
         "wk:page":"Calgary"
@@ -518,7 +519,8 @@
         }
     ],
     "wof:id":890458845,
-    "wof:lastmodified":1582309935,
+    "wof:lastmodified":1608688178,
+    "wof:megacity":1,
     "wof:name":"Calgary",
     "wof:parent_id":1511799789,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary