### PR TITLE
Add airport codes as name variants

### DIFF
--- a/data/102/554/157/102554157.geojson
+++ b/data/102/554/157/102554157.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-69.9558333333,58.6677777778,-69.9558333333,58.6677777778",
+    "geom:bbox":"-69.955833,58.667778,-69.955833,58.667778",
     "geom:latitude":58.667778,
     "geom:longitude":-69.955833,
     "iso:country":"CA",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "Tasiujaq Airport"
+    ],
+    "name:eng_x_variant":[
+        "YTQ",
+        "CYTQ"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u062a\u0627\u0633\u06cc\u0648\u062c\u0627\u06a9"
@@ -60,7 +64,7 @@
         "wd:id":"Q3912840"
     },
     "wof:country":"CA",
-    "wof:geomhash":"ffd1ceb65a5e6335655adf3782b90e8b",
+    "wof:geomhash":"beefe81883684365873b5239b284c5c0",
     "wof:hierarchy":[
         {
             "campus_id":102554157,
@@ -69,7 +73,7 @@
         }
     ],
     "wof:id":102554157,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Tasiujuaq Airport",
     "wof:parent_id":85633041,
     "wof:placetype":"campus",
@@ -81,10 +85,10 @@
     ]
 },
   "bbox": [
-    -69.955833333333,
-    58.667777777778,
-    -69.955833333333,
-    58.667777777778
+    -69.955833,
+    58.667778,
+    -69.955833,
+    58.667778
 ],
-  "geometry": {"coordinates":[-69.955833333333,58.667777777778],"type":"Point"}
+  "geometry": {"coordinates":[-69.955833,58.667778],"type":"Point"}
 }

--- a/data/102/554/177/102554177.geojson
+++ b/data/102/554/177/102554177.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-134.859722222,67.4069444444,-134.859722222,67.4069444444",
+    "geom:bbox":"-134.859722,67.406944,-134.859722,67.406944",
     "geom:latitude":67.406944,
     "geom:longitude":-134.859722,
     "iso:country":"CA",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "Fort McPherson Airport"
+    ],
+    "name:eng_x_variant":[
+        "ZFM",
+        "CZFM"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0641\u0648\u0631\u062a \u0645\u06a9\u200c\u0641\u0631\u0633\u0648\u0646"
@@ -65,7 +69,7 @@
         "wd:id":"Q3912560"
     },
     "wof:country":"CA",
-    "wof:geomhash":"ba9aa0b0a1ecc7c4377c1af7227db7f9",
+    "wof:geomhash":"ea2a829a63ec4a2895e1c476ab8ec3a9",
     "wof:hierarchy":[
         {
             "campus_id":102554177,
@@ -75,7 +79,7 @@
         }
     ],
     "wof:id":102554177,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734362,
     "wof:name":"Fort Mcpherson Airport",
     "wof:parent_id":101735391,
     "wof:placetype":"campus",
@@ -87,10 +91,10 @@
     ]
 },
   "bbox": [
-    -134.85972222222,
-    67.406944444444,
-    -134.85972222222,
-    67.406944444444
+    -134.859722,
+    67.406944,
+    -134.859722,
+    67.406944
 ],
-  "geometry": {"coordinates":[-134.85972222222,67.40694444444399],"type":"Point"}
+  "geometry": {"coordinates":[-134.859722,67.406944],"type":"Point"}
 }

--- a/data/102/554/399/102554399.geojson
+++ b/data/102/554/399/102554399.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-121.975833333,56.0355555556,-121.975833333,56.0355555556",
+    "geom:bbox":"-121.975833,56.035556,-121.975833,56.035556",
     "geom:latitude":56.035556,
     "geom:longitude":-121.975833,
     "iso:country":"CA",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "Hudson's Hope Airport"
+    ],
+    "name:eng_x_variant":[
+        "YNH",
+        "CYNH"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0647\u0648\u062f\u0633\u0646\u0632 \u0647\u0648\u067e"
@@ -62,7 +66,7 @@
         "wd:id":"Q3207300"
     },
     "wof:country":"CA",
-    "wof:geomhash":"3f04434c7db30bc928256140168ccc5e",
+    "wof:geomhash":"0d9785f631e7536a78cfa4c78faae861",
     "wof:hierarchy":[
         {
             "campus_id":102554399,
@@ -72,7 +76,7 @@
         }
     ],
     "wof:id":102554399,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Hudsons Hope Airport",
     "wof:parent_id":101740891,
     "wof:placetype":"campus",
@@ -84,10 +88,10 @@
     ]
 },
   "bbox": [
-    -121.97583333333,
-    56.035555555556,
-    -121.97583333333,
-    56.035555555556
+    -121.975833,
+    56.035556,
+    -121.975833,
+    56.035556
 ],
-  "geometry": {"coordinates":[-121.97583333333,56.035555555556],"type":"Point"}
+  "geometry": {"coordinates":[-121.97583299999999,56.035556],"type":"Point"}
 }

--- a/data/102/554/465/102554465.geojson
+++ b/data/102/554/465/102554465.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Hearst"
     ],
+    "name:eng_x_variant":[
+        "YHF",
+        "CYHF"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0647\u0631\u0633\u062a"
     ],
@@ -71,7 +75,7 @@
         }
     ],
     "wof:id":102554465,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734362,
     "wof:name":"Hearst Municipal Airport",
     "wof:parent_id":101735693,
     "wof:placetype":"campus",

--- a/data/102/554/473/102554473.geojson
+++ b/data/102/554/473/102554473.geojson
@@ -25,6 +25,10 @@
     "name:eng_x_preferred":[
         "Edmonton International Airport"
     ],
+    "name:eng_x_variant":[
+        "YEG",
+        "CYEG"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0628\u06cc\u0646\u200c\u0627\u0644\u0645\u0644\u0644\u06cc \u0627\u062f\u0645\u0648\u0646\u062a\u0648\u0646"
     ],
@@ -121,7 +125,7 @@
         }
     ],
     "wof:id":102554473,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734362,
     "wof:name":"Edmonton International Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/102/554/493/102554493.geojson
+++ b/data/102/554/493/102554493.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Earlton"
     ],
+    "name:eng_x_variant":[
+        "YXR",
+        "CYXR"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0627\u0631\u0644\u062a\u0648\u0646"
     ],
@@ -74,7 +78,7 @@
         }
     ],
     "wof:id":102554493,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734362,
     "wof:name":"Earlton Airport",
     "wof:parent_id":101735733,
     "wof:placetype":"campus",

--- a/data/102/554/519/102554519.geojson
+++ b/data/102/554/519/102554519.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-60.4258333333,53.3191666667,-60.4258333333,53.3191666667",
+    "geom:bbox":"-60.425833,53.319167,-60.425833,53.319167",
     "geom:latitude":53.319167,
     "geom:longitude":-60.425833,
     "iso:country":"CA",
@@ -21,6 +21,10 @@
     ],
     "name:eng_x_preferred":[
         "CFB Goose Bay"
+    ],
+    "name:eng_x_variant":[
+        "YYR",
+        "CYYR"
     ],
     "name:fas_x_preferred":[
         "\u0633\u06cc\u200c\u0627\u0641\u200c\u0628\u06cc \u06af\u0648\u0633 \u0628\u06cc"
@@ -73,7 +77,7 @@
         "wd:id":"Q1032124"
     },
     "wof:country":"CA",
-    "wof:geomhash":"9b8b4aac33698b12b0a4dcd7327914ac",
+    "wof:geomhash":"b8ccdd6f2e225e2dcb1d52aaaad416ae",
     "wof:hierarchy":[
         {
             "campus_id":102554519,
@@ -82,7 +86,7 @@
         }
     ],
     "wof:id":102554519,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734362,
     "wof:name":"Goose Bay Airport",
     "wof:parent_id":85682123,
     "wof:placetype":"campus",
@@ -94,10 +98,10 @@
     ]
 },
   "bbox": [
-    -60.425833333333,
-    53.319166666667,
-    -60.425833333333,
-    53.319166666667
+    -60.425833,
+    53.319167,
+    -60.425833,
+    53.319167
 ],
-  "geometry": {"coordinates":[-60.425833333333,53.319166666667],"type":"Point"}
+  "geometry": {"coordinates":[-60.425833,53.319167],"type":"Point"}
 }

--- a/data/102/554/549/102554549.geojson
+++ b/data/102/554/549/102554549.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-101.681944444,54.6780555556,-101.681944444,54.6780555556",
+    "geom:bbox":"-101.681944,54.678056,-101.681944,54.678056",
     "geom:latitude":54.678056,
     "geom:longitude":-101.681944,
     "iso:country":"CA",
@@ -21,6 +21,10 @@
     ],
     "name:eng_x_preferred":[
         "Flin Flon Airport"
+    ],
+    "name:eng_x_variant":[
+        "YFO",
+        "CYFO"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0641\u0644\u06cc\u0646 \u0641\u0644\u0648\u0646"
@@ -63,7 +67,7 @@
         "wd:id":"Q1431291"
     },
     "wof:country":"CA",
-    "wof:geomhash":"a483c513d811842a57e5cc04bded5250",
+    "wof:geomhash":"b192feff4a1f1b79184a332c6e480612",
     "wof:hierarchy":[
         {
             "campus_id":102554549,
@@ -72,7 +76,7 @@
         }
     ],
     "wof:id":102554549,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734362,
     "wof:name":"Flin Flon Municipal Airport",
     "wof:parent_id":85682085,
     "wof:placetype":"campus",
@@ -84,10 +88,10 @@
     ]
 },
   "bbox": [
-    -101.68194444444,
-    54.678055555556,
-    -101.68194444444,
-    54.678055555556
+    -101.681944,
+    54.678056,
+    -101.681944,
+    54.678056
 ],
-  "geometry": {"coordinates":[-101.68194444444001,54.678055555556],"type":"Point"}
+  "geometry": {"coordinates":[-101.681944,54.678056],"type":"Point"}
 }

--- a/data/102/554/551/102554551.geojson
+++ b/data/102/554/551/102554551.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Gore Bay-Manitoulin Airport"
     ],
+    "name:eng_x_variant":[
+        "YZE",
+        "CYZE"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u06af\u0631 \u0628\u0627\u06cc-\u0645\u0627\u0646\u06cc\u062a\u0648\u0644\u06cc\u0646"
     ],
@@ -72,7 +76,7 @@
         }
     ],
     "wof:id":102554551,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Manitoulin Airport",
     "wof:parent_id":101735765,
     "wof:placetype":"campus",

--- a/data/102/554/579/102554579.geojson
+++ b/data/102/554/579/102554579.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Yorkton Municipal Airport"
     ],
+    "name:eng_x_variant":[
+        "YQV",
+        "CYQV"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0634\u0647\u0631\u06cc \u06cc\u0648\u0631\u06a9\u062a\u0646"
     ],
@@ -71,7 +75,7 @@
         }
     ],
     "wof:id":102554579,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734362,
     "wof:name":"Yorkton Airport",
     "wof:parent_id":101740569,
     "wof:placetype":"campus",

--- a/data/102/554/727/102554727.geojson
+++ b/data/102/554/727/102554727.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-85.8119444444,79.9944444444,-85.8119444444,79.9944444444",
+    "geom:bbox":"-85.811944,79.994444,-85.811944,79.994444",
     "geom:latitude":79.994444,
     "geom:longitude":-85.811944,
     "iso:country":"CA",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "Eureka Aerodrome"
+    ],
+    "name:eng_x_variant":[
+        "YEU",
+        "CYEU"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0627\u0648\u0631\u06cc\u06a9\u0627"
@@ -70,7 +74,7 @@
         "wd:id":"Q3914292"
     },
     "wof:country":"CA",
-    "wof:geomhash":"b4d1e1184960ea953dc1e7cf656cac12",
+    "wof:geomhash":"3bf2e04ee518a85184d6df7c243fd9f8",
     "wof:hierarchy":[
         {
             "campus_id":102554727,
@@ -79,7 +83,7 @@
         }
     ],
     "wof:id":102554727,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734362,
     "wof:name":"Eureka Airport",
     "wof:parent_id":85682105,
     "wof:placetype":"campus",
@@ -91,10 +95,10 @@
     ]
 },
   "bbox": [
-    -85.811944444444,
-    79.994444444444,
-    -85.811944444444,
-    79.994444444444
+    -85.811944,
+    79.994444,
+    -85.811944,
+    79.994444
 ],
-  "geometry": {"coordinates":[-85.81194444444399,79.994444444444],"type":"Point"}
+  "geometry": {"coordinates":[-85.811944,79.994444],"type":"Point"}
 }

--- a/data/102/555/093/102555093.geojson
+++ b/data/102/555/093/102555093.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Princeton Aerodrome"
     ],
+    "name:eng_x_variant":[
+        "CYDC"
+    ],
     "name:fas_x_preferred":[
         "\u067e\u0627\u06cc\u06af\u0627\u0647 \u0647\u0648\u0627\u06cc\u06cc \u067e\u0631\u06cc\u0646\u0633\u062a\u0646"
     ],
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":102555093,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Princeton Airport",
     "wof:parent_id":101741119,
     "wof:placetype":"campus",

--- a/data/102/555/173/102555173.geojson
+++ b/data/102/555/173/102555173.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Sparwood/Elk Valley Airport"
     ],
+    "name:eng_x_variant":[
+        "CYSW"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0627\u0633\u067e\u0627\u0631\u0648\u0648\u062f/\u0627\u0644\u06a9 \u0648\u0644\u06cc"
     ],
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":102555173,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Sparwood Elk Valley Airport",
     "wof:parent_id":85682117,
     "wof:placetype":"campus",

--- a/data/102/555/199/102555199.geojson
+++ b/data/102/555/199/102555199.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Rimouski Airport"
     ],
+    "name:eng_x_variant":[
+        "YXK",
+        "CYXK"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0631\u06cc\u0645\u0648\u0633\u06a9\u06cc"
     ],
@@ -78,7 +82,7 @@
         }
     ],
     "wof:id":102555199,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"A\u00e9roport de Rimouski",
     "wof:parent_id":101737831,
     "wof:placetype":"campus",

--- a/data/102/555/213/102555213.geojson
+++ b/data/102/555/213/102555213.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Texada/Gillies Bay Airport"
     ],
+    "name:eng_x_variant":[
+        "YGB",
+        "CYGB"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u062a\u0633\u0627\u062f\u0627/\u062e\u0644\u06cc\u062c \u06af\u06cc\u0644\u0627\u06cc\u0633"
     ],
@@ -73,7 +77,7 @@
         }
     ],
     "wof:id":102555213,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Gillies Bay Airport",
     "wof:parent_id":85682117,
     "wof:placetype":"campus",

--- a/data/102/555/227/102555227.geojson
+++ b/data/102/555/227/102555227.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-66.2655555556,50.2233333333,-66.2655555556,50.2233333333",
+    "geom:bbox":"-66.265556,50.223333,-66.265556,50.223333",
     "geom:latitude":50.223333,
     "geom:longitude":-66.265556,
     "iso:country":"CA",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "Sept-\u00celes Airport"
+    ],
+    "name:eng_x_variant":[
+        "YZV",
+        "CYZV"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0633\u067e\u062a\u200c\u0627\u0626\u06cc\u0644\u0633"
@@ -66,7 +70,7 @@
         "wd:id":"Q2875916"
     },
     "wof:country":"CA",
-    "wof:geomhash":"d99594ecd1e1e1e8bff8ed26d3517e66",
+    "wof:geomhash":"269ad0c15234df06268316b0d73f2674",
     "wof:hierarchy":[
         {
             "campus_id":102555227,
@@ -75,7 +79,7 @@
         }
     ],
     "wof:id":102555227,
-    "wof:lastmodified":1566518862,
+    "wof:lastmodified":1631734361,
     "wof:name":"A\u00e9roport de Sept-\u00celes",
     "wof:parent_id":101737833,
     "wof:placetype":"campus",
@@ -87,10 +91,10 @@
     ]
 },
   "bbox": [
-    -66.265555555556,
-    50.223333333333,
-    -66.265555555556,
-    50.223333333333
+    -66.265556,
+    50.223333,
+    -66.265556,
+    50.223333
 ],
-  "geometry": {"coordinates":[-66.26555555555601,50.223333333333],"type":"Point"}
+  "geometry": {"coordinates":[-66.265556,50.223333],"type":"Point"}
 }

--- a/data/102/555/355/102555355.geojson
+++ b/data/102/555/355/102555355.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Penticton Regional Airport"
     ],
+    "name:eng_x_variant":[
+        "YYF",
+        "CYYF"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0645\u0646\u0637\u0642\u0647\u200c\u0627\u06cc \u067e\u0646\u062a\u06cc\u06a9\u062a\u0648\u0646"
     ],
@@ -78,7 +82,7 @@
         }
     ],
     "wof:id":102555355,
-    "wof:lastmodified":1566518862,
+    "wof:lastmodified":1631734361,
     "wof:name":"Penticton Airport",
     "wof:parent_id":101740921,
     "wof:placetype":"campus",

--- a/data/102/555/381/102555381.geojson
+++ b/data/102/555/381/102555381.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-72.7888888889,47.4097222222,-72.7888888889,47.4097222222",
+    "geom:bbox":"-72.788889,47.409722,-72.788889,47.409722",
     "geom:latitude":47.409722,
     "geom:longitude":-72.788889,
     "iso:country":"CA",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "La Tuque Airport"
+    ],
+    "name:eng_x_variant":[
+        "YLQ",
+        "CYLQ"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0644\u0627 \u062a\u0648\u06a9"
@@ -60,7 +64,7 @@
         "wd:id":"Q3914332"
     },
     "wof:country":"CA",
-    "wof:geomhash":"3d40b70449fce01b017f1523c3734a55",
+    "wof:geomhash":"54df1d66c4d29a4c264f86b7c7fba03b",
     "wof:hierarchy":[
         {
             "campus_id":102555381,
@@ -69,7 +73,7 @@
         }
     ],
     "wof:id":102555381,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"A\u00e9roport Municipal de la Tuque",
     "wof:parent_id":101737199,
     "wof:placetype":"campus",
@@ -81,10 +85,10 @@
     ]
 },
   "bbox": [
-    -72.788888888889,
-    47.409722222222,
-    -72.788888888889,
-    47.409722222222
+    -72.788889,
+    47.409722,
+    -72.788889,
+    47.409722
 ],
-  "geometry": {"coordinates":[-72.78888888888901,47.409722222222],"type":"Point"}
+  "geometry": {"coordinates":[-72.788889,47.409722],"type":"Point"}
 }

--- a/data/102/555/385/102555385.geojson
+++ b/data/102/555/385/102555385.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Lac La Biche Airport"
     ],
+    "name:eng_x_variant":[
+        "YLB",
+        "CYLB"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0644\u06a9 \u0644\u0627 \u0628\u06cc\u0686"
     ],
@@ -73,7 +77,7 @@
         }
     ],
     "wof:id":102555385,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Lac la Biche Airport",
     "wof:parent_id":85682091,
     "wof:placetype":"campus",

--- a/data/102/555/431/102555431.geojson
+++ b/data/102/555/431/102555431.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "North Battleford"
     ],
+    "name:eng_x_variant":[
+        "YQW",
+        "CYQW"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0646\u0648\u0631\u062b \u0628\u062a\u0644\u0641\u0648\u0631\u062f"
     ],
@@ -69,7 +73,7 @@
         }
     ],
     "wof:id":102555431,
-    "wof:lastmodified":1566518862,
+    "wof:lastmodified":1631734361,
     "wof:name":"North Battleford Airport",
     "wof:parent_id":101739893,
     "wof:placetype":"campus",

--- a/data/102/555/467/102555467.geojson
+++ b/data/102/555/467/102555467.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Pemberton Aerodrome"
     ],
+    "name:eng_x_variant":[
+        "CYPS"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0622\u0628\u06cc \u067e\u0645\u0628\u0631\u062a\u0648\u0646"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":102555467,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Pemberton Airport",
     "wof:parent_id":101740991,
     "wof:placetype":"campus",

--- a/data/102/555/507/102555507.geojson
+++ b/data/102/555/507/102555507.geojson
@@ -22,6 +22,10 @@
     "name:eng_x_preferred":[
         "Inuvik"
     ],
+    "name:eng_x_variant":[
+        "YEV",
+        "CYEV"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0627\u06cc\u0646\u0648\u0648\u06cc\u06a9 \u0645\u0627\u06cc\u06a9 \u0632\u0648\u0628\u06a9\u0648"
     ],
@@ -83,7 +87,7 @@
         }
     ],
     "wof:id":102555507,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Inuvik Airport",
     "wof:parent_id":101735407,
     "wof:placetype":"campus",

--- a/data/102/555/517/102555517.geojson
+++ b/data/102/555/517/102555517.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-57.1861111111,51.4419444444,-57.1861111111,51.4419444444",
+    "geom:bbox":"-57.186111,51.441944,-57.186111,51.441944",
     "geom:latitude":51.441944,
     "geom:longitude":-57.186111,
     "iso:country":"CA",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "Lourdes-de-Blanc-Sablon Airport"
+    ],
+    "name:eng_x_variant":[
+        "YBX",
+        "CYBX"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0644\u0648\u0631\u062f\u0632 \u062f \u0628\u0644\u0627\u0646\u06a9 \u0633\u0627\u0628\u0644\u0648\u0646"
@@ -66,7 +70,7 @@
         "wd:id":"Q3912632"
     },
     "wof:country":"CA",
-    "wof:geomhash":"dbe8ef201f03a4467388dd30611e49de",
+    "wof:geomhash":"4e9c816e4e2a86d00aea2a8bd8f82705",
     "wof:hierarchy":[
         {
             "campus_id":102555517,
@@ -75,7 +79,7 @@
         }
     ],
     "wof:id":102555517,
-    "wof:lastmodified":1566518863,
+    "wof:lastmodified":1631734361,
     "wof:name":"Aeroport d\u00e9 Lourdes-d\u00e9-Blanc-Sablon",
     "wof:parent_id":101737663,
     "wof:placetype":"campus",
@@ -87,10 +91,10 @@
     ]
 },
   "bbox": [
-    -57.186111111111,
-    51.441944444444,
-    -57.186111111111,
-    51.441944444444
+    -57.186111,
+    51.441944,
+    -57.186111,
+    51.441944
 ],
-  "geometry": {"coordinates":[-57.186111111111,51.441944444444],"type":"Point"}
+  "geometry": {"coordinates":[-57.186111,51.441944],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1963

This PR adds existing `iata:code and `icao:code` concordance values as English name variants. If these changes (and two other related PRs) look good, I'll apply them directly to each admin repo.