### PR TITLE
ca concordances, placetype local, and more

### DIFF
--- a/data/115/886/315/3/1158863153.geojson
+++ b/data/115/886/315/3/1158863153.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"1",
+        "can-abog:pid":"29860"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380898,
     "wof:geomhash":"16cec67c7addc2a18f48d9d1451f402b",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863153,
-    "wof:lastmodified":1694497962,
+    "wof:lastmodified":1695886227,
     "wof:name":"Acadia No. 34",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/315/5/1158863155.geojson
+++ b/data/115/886/315/5/1158863155.geojson
@@ -121,6 +121,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"12",
+        "can-abog:pid":"29863"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380899,
     "wof:geomhash":"6fd1c833e86bbb23ebd3afdb865205e0",
@@ -133,7 +141,7 @@
         }
     ],
     "wof:id":1158863155,
-    "wof:lastmodified":1694498094,
+    "wof:lastmodified":1695886491,
     "wof:name":"Athabasca",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/315/9/1158863159.geojson
+++ b/data/115/886/315/9/1158863159.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"15",
+        "can-abog:pid":"29864"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380899,
     "wof:geomhash":"9d1f132d060da587e7a2729fe7555320",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863159,
-    "wof:lastmodified":1694497964,
+    "wof:lastmodified":1695886234,
     "wof:name":"Barrhead No. 11",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/316/1/1158863161.geojson
+++ b/data/115/886/316/1/1158863161.geojson
@@ -295,6 +295,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"20",
+        "can-abog:pid":"29865"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380900,
     "wof:geomhash":"632683bf556a2501a67288664f644a33",
@@ -307,7 +315,7 @@
         }
     ],
     "wof:id":1158863161,
-    "wof:lastmodified":1694498095,
+    "wof:lastmodified":1695886495,
     "wof:name":"Beaver",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/316/3/1158863163.geojson
+++ b/data/115/886/316/3/1158863163.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"36",
+        "can-abog:pid":"29869"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380900,
     "wof:geomhash":"2ae5c491c199bcb364327339c6b9ca5e",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863163,
-    "wof:lastmodified":1694497964,
+    "wof:lastmodified":1695886235,
     "wof:name":"Bonnyville No. 87",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/316/5/1158863165.geojson
+++ b/data/115/886/316/5/1158863165.geojson
@@ -70,6 +70,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"49",
+        "can-abog:pid":"29871"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380901,
     "wof:geomhash":"7b9633de811371fea38a639789f49918",
@@ -82,7 +90,7 @@
         }
     ],
     "wof:id":1158863165,
-    "wof:lastmodified":1694498095,
+    "wof:lastmodified":1695886496,
     "wof:name":"Camrose",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/316/7/1158863167.geojson
+++ b/data/115/886/316/7/1158863167.geojson
@@ -73,6 +73,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"53",
+        "can-abog:pid":"29872"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380902,
     "wof:geomhash":"7bb9ea545b1f62c090bb63a73181807b",
@@ -85,7 +93,7 @@
         }
     ],
     "wof:id":1158863167,
-    "wof:lastmodified":1694497825,
+    "wof:lastmodified":1695886607,
     "wof:name":"Cardston",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/316/9/1158863169.geojson
+++ b/data/115/886/316/9/1158863169.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"107",
+        "can-abog:pid":"29854"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380903,
     "wof:geomhash":"7de63fc29ab8d3d7aba0ab3677b680db",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863169,
-    "wof:lastmodified":1694498002,
+    "wof:lastmodified":1695886336,
     "wof:name":"Fairview No. 136",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/317/1/1158863171.geojson
+++ b/data/115/886/317/1/1158863171.geojson
@@ -82,6 +82,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"110",
+        "can-abog:pid":"29852"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380903,
     "wof:geomhash":"5fb19779ea639fe613975a8585a402ab",
@@ -94,7 +102,7 @@
         }
     ],
     "wof:id":1158863171,
-    "wof:lastmodified":1694497826,
+    "wof:lastmodified":1695886608,
     "wof:name":"Flagstaff",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/317/3/1158863173.geojson
+++ b/data/115/886/317/3/1158863173.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"111",
+        "can-abog:pid":"29868"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380904,
     "wof:geomhash":"9e9fc16295a79c4ed36f62f4b56f108c",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863173,
-    "wof:lastmodified":1694498003,
+    "wof:lastmodified":1695886336,
     "wof:name":"Foothills No. 31",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/317/7/1158863177.geojson
+++ b/data/115/886/317/7/1158863177.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"118",
+        "can-abog:pid":"29849"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380905,
     "wof:geomhash":"7507148828e1a99ac52edc3ab7074560",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863177,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886522,
     "wof:name":"Forty Mile No. 8",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/317/9/1158863179.geojson
+++ b/data/115/886/317/9/1158863179.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"133",
+        "can-abog:pid":"29850"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380905,
     "wof:geomhash":"d8c9780c48eca23e3b93032dd083c887",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863179,
-    "wof:lastmodified":1694498003,
+    "wof:lastmodified":1695886338,
     "wof:name":"Grande Prairie No. 1",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/318/1/1158863181.geojson
+++ b/data/115/886/318/1/1158863181.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"159",
+        "can-abog:pid":"29846"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380906,
     "wof:geomhash":"fccabb30a25119da9f258d0a8a5710cc",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863181,
-    "wof:lastmodified":1694497967,
+    "wof:lastmodified":1695886243,
     "wof:name":"I.D. No. 4 (Waterton)",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/318/3/1158863183.geojson
+++ b/data/115/886/318/3/1158863183.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"164",
+        "can-abog:pid":"29911"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380907,
     "wof:geomhash":"277114145c1958132156bea5e12fbf22",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863183,
-    "wof:lastmodified":1694497967,
+    "wof:lastmodified":1695886243,
     "wof:name":"I.D. No. 9 (Banff)",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/318/5/1158863185.geojson
+++ b/data/115/886/318/5/1158863185.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"167",
+        "can-abog:pid":"29845"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380908,
     "wof:geomhash":"48c3d1f4f1aae746cc0835597f48ba5b",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863185,
-    "wof:lastmodified":1694497966,
+    "wof:lastmodified":1695886241,
     "wof:name":"I.D. No. 12 (Jasper National Park)",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/318/7/1158863187.geojson
+++ b/data/115/886/318/7/1158863187.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"168",
+        "can-abog:pid":"29844"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380909,
     "wof:geomhash":"e2193765be61eec3c02e0a0c58f55771",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863187,
-    "wof:lastmodified":1694497967,
+    "wof:lastmodified":1695886242,
     "wof:name":"I.D. No. 13 (Elk Island)",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/318/9/1158863189.geojson
+++ b/data/115/886/318/9/1158863189.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"179",
+        "can-abog:pid":"29843"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380910,
     "wof:geomhash":"299b1e301f65a9d7853a475a6ff1803d",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863189,
-    "wof:lastmodified":1694498179,
+    "wof:lastmodified":1695886496,
     "wof:name":"I.D. No. 24 (Wood Buffalo)",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/319/1/1158863191.geojson
+++ b/data/115/886/319/1/1158863191.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"191",
+        "can-abog:pid":"29851"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380910,
     "wof:geomhash":"00b2e66065232a594bae868eeee592cd",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863191,
-    "wof:lastmodified":1694498021,
+    "wof:lastmodified":1695886391,
     "wof:name":"Kneehill",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/319/5/1158863195.geojson
+++ b/data/115/886/319/5/1158863195.geojson
@@ -58,6 +58,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"193",
+        "can-abog:pid":"29861"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380912,
     "wof:geomhash":"4cd6c86c1aa61e8b9ba68e60d5e1b2b7",
@@ -70,7 +78,7 @@
         }
     ],
     "wof:id":1158863195,
-    "wof:lastmodified":1694497826,
+    "wof:lastmodified":1695886610,
     "wof:name":"Lac Ste. Anne",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/319/7/1158863197.geojson
+++ b/data/115/886/319/7/1158863197.geojson
@@ -91,6 +91,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"195",
+        "can-abog:pid":"29853"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380912,
     "wof:geomhash":"45b1c5a08c03c1069532b3deba3516f9",
@@ -103,7 +111,7 @@
         }
     ],
     "wof:id":1158863197,
-    "wof:lastmodified":1694497826,
+    "wof:lastmodified":1695886609,
     "wof:name":"Lacombe",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/319/9/1158863199.geojson
+++ b/data/115/886/319/9/1158863199.geojson
@@ -85,6 +85,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"198",
+        "can-abog:pid":"29855"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380913,
     "wof:geomhash":"bc1e4ca962df970cf68361a9d79e6bd8",
@@ -97,7 +105,7 @@
         }
     ],
     "wof:id":1158863199,
-    "wof:lastmodified":1694497826,
+    "wof:lastmodified":1695886610,
     "wof:name":"Lamont",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/320/1/1158863201.geojson
+++ b/data/115/886/320/1/1158863201.geojson
@@ -64,6 +64,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"201",
+        "can-abog:pid":"29856"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380914,
     "wof:geomhash":"98c58b0885e2963a21fa67ed899b53d9",
@@ -76,7 +84,7 @@
         }
     ],
     "wof:id":1158863201,
-    "wof:lastmodified":1694497824,
+    "wof:lastmodified":1695886604,
     "wof:name":"Leduc",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/320/3/1158863203.geojson
+++ b/data/115/886/320/3/1158863203.geojson
@@ -157,6 +157,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"204",
+        "can-abog:pid":"29858"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380915,
     "wof:geomhash":"b40cda808261cf1cf119bc3aec42f39f",
@@ -169,7 +177,7 @@
         }
     ],
     "wof:id":1158863203,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886503,
     "wof:name":"Lethbridge",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/320/5/1158863205.geojson
+++ b/data/115/886/320/5/1158863205.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"222",
+        "can-abog:pid":"29859"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380915,
     "wof:geomhash":"3b181fdb65e74ba1405c11e5c24aff78",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863205,
-    "wof:lastmodified":1694498025,
+    "wof:lastmodified":1695886402,
     "wof:name":"Minburn No. 27",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/320/7/1158863207.geojson
+++ b/data/115/886/320/7/1158863207.geojson
@@ -106,6 +106,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"226",
+        "can-abog:pid":"29879"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380917,
     "wof:geomhash":"0bf9d6549fbf477b55a4516f0b06fb49",
@@ -118,7 +126,7 @@
         }
     ],
     "wof:id":1158863207,
-    "wof:lastmodified":1694497823,
+    "wof:lastmodified":1695886603,
     "wof:name":"Mountain View",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/320/9/1158863209.geojson
+++ b/data/115/886/320/9/1158863209.geojson
@@ -91,6 +91,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"235",
+        "can-abog:pid":"29848"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380918,
     "wof:geomhash":"b51d9ae60f4775b21f3b5de4390efb37",
@@ -103,7 +111,7 @@
         }
     ],
     "wof:id":1158863209,
-    "wof:lastmodified":1694497824,
+    "wof:lastmodified":1695886603,
     "wof:name":"Newell",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/321/3/1158863213.geojson
+++ b/data/115/886/321/3/1158863213.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"243",
+        "can-abog:pid":"29895"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380919,
     "wof:geomhash":"f61ee13a61f9a1fe6c92b708448071d1",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863213,
-    "wof:lastmodified":1694497965,
+    "wof:lastmodified":1695886239,
     "wof:name":"Paintearth No. 18",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/321/5/1158863215.geojson
+++ b/data/115/886/321/5/1158863215.geojson
@@ -82,6 +82,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"245",
+        "can-abog:pid":"29896"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380920,
     "wof:geomhash":"b5c967a40154d76a2d7320a0a85d8840",
@@ -94,7 +102,7 @@
         }
     ],
     "wof:id":1158863215,
-    "wof:lastmodified":1694497827,
+    "wof:lastmodified":1695886612,
     "wof:name":"Parkland",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/321/7/1158863217.geojson
+++ b/data/115/886/321/7/1158863217.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"246",
+        "can-abog:pid":"29897"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380920,
     "wof:geomhash":"6e025c71892700bd118a0f2aae2f5423",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863217,
-    "wof:lastmodified":1694498025,
+    "wof:lastmodified":1695886403,
     "wof:name":"Peace No. 135",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/321/9/1158863219.geojson
+++ b/data/115/886/321/9/1158863219.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"251",
+        "can-abog:pid":"29898"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380923,
     "wof:geomhash":"4d174b9facdfbfde6da064b8c34094fb",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863219,
-    "wof:lastmodified":1694498026,
+    "wof:lastmodified":1695886404,
     "wof:name":"Pincher Creek No. 9",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/322/1/1158863221.geojson
+++ b/data/115/886/322/1/1158863221.geojson
@@ -52,6 +52,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"255",
+        "can-abog:pid":"29908"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380923,
     "wof:geomhash":"1fc216f1ecc94268e878fe20c2c13a48",
@@ -64,7 +72,7 @@
         }
     ],
     "wof:id":1158863221,
-    "wof:lastmodified":1694498026,
+    "wof:lastmodified":1695886404,
     "wof:name":"Ponoka",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/322/3/1158863223.geojson
+++ b/data/115/886/322/3/1158863223.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"258",
+        "can-abog:pid":"29900"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380925,
     "wof:geomhash":"dc7dc95be1126a893e219f1e277563ec",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863223,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886527,
     "wof:name":"Provost No. 52",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/322/5/1158863225.geojson
+++ b/data/115/886/322/5/1158863225.geojson
@@ -52,6 +52,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"263",
+        "can-abog:pid":"29902"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380928,
     "wof:geomhash":"5e09fa6d8891dfa9dc905b50a935a085",
@@ -64,7 +72,7 @@
         }
     ],
     "wof:id":1158863225,
-    "wof:lastmodified":1694498094,
+    "wof:lastmodified":1695886492,
     "wof:name":"Red Deer",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/322/7/1158863227.geojson
+++ b/data/115/886/322/7/1158863227.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"269",
+        "can-abog:pid":"29903"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380929,
     "wof:geomhash":"4288954e63529942f20072e40cc88ce2",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863227,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886528,
     "wof:name":"Rocky View",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/323/1/1158863231.geojson
+++ b/data/115/886/323/1/1158863231.geojson
@@ -70,6 +70,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"286",
+        "can-abog:pid":"29905"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380929,
     "wof:geomhash":"6d120af2c15f3821a634627ff87917d5",
@@ -82,7 +90,7 @@
         }
     ],
     "wof:id":1158863231,
-    "wof:lastmodified":1694497822,
+    "wof:lastmodified":1695886600,
     "wof:name":"Smoky Lake",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/323/3/1158863233.geojson
+++ b/data/115/886/323/3/1158863233.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"287",
+        "can-abog:pid":"29906"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380930,
     "wof:geomhash":"320f4e3eb1ab64c845f46a28164f89ae",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863233,
-    "wof:lastmodified":1694498179,
+    "wof:lastmodified":1695886498,
     "wof:name":"Smoky River No. 130",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/323/5/1158863235.geojson
+++ b/data/115/886/323/5/1158863235.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"290",
+        "can-abog:pid":"29907"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380930,
     "wof:geomhash":"d6ca93582ecb99387fb542831fc02423",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863235,
-    "wof:lastmodified":1694498042,
+    "wof:lastmodified":1695886451,
     "wof:name":"Spirit River No. 133",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/323/7/1158863237.geojson
+++ b/data/115/886/323/7/1158863237.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"294",
+        "can-abog:pid":"29886"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380931,
     "wof:geomhash":"8ff3b54213a0c3ec515f4c6c49828efc",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863237,
-    "wof:lastmodified":1694497966,
+    "wof:lastmodified":1695886239,
     "wof:name":"St. Paul No. 19",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/323/9/1158863239.geojson
+++ b/data/115/886/323/9/1158863239.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"296",
+        "can-abog:pid":"29884"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380932,
     "wof:geomhash":"b9da15efdeb87256d4a3982b8da71968",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863239,
-    "wof:lastmodified":1694497966,
+    "wof:lastmodified":1695886240,
     "wof:name":"Starland",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/324/1/1158863241.geojson
+++ b/data/115/886/324/1/1158863241.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"299",
+        "can-abog:pid":"29899"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380932,
     "wof:geomhash":"2a7cf70e49cd2e6ec4e65c69c15341b5",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863241,
-    "wof:lastmodified":1694497966,
+    "wof:lastmodified":1695886240,
     "wof:name":"Stettler No. 6",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/324/3/1158863243.geojson
+++ b/data/115/886/324/3/1158863243.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"302",
+        "can-abog:pid":"29839"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380933,
     "wof:geomhash":"851b4601bb659751e5537161a37809b5",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863243,
-    "wof:lastmodified":1694497822,
+    "wof:lastmodified":1695886601,
     "wof:name":"Strathcona",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/324/5/1158863245.geojson
+++ b/data/115/886/324/5/1158863245.geojson
@@ -208,6 +208,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"305",
+        "can-abog:pid":"29880"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380934,
     "wof:geomhash":"4e2faa159a2df978a283e45025e8d46b",
@@ -220,7 +228,7 @@
         }
     ],
     "wof:id":1158863245,
-    "wof:lastmodified":1694497822,
+    "wof:lastmodified":1695886601,
     "wof:name":"Sturgeon",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/324/9/1158863249.geojson
+++ b/data/115/886/324/9/1158863249.geojson
@@ -52,6 +52,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"312",
+        "can-abog:pid":"29881"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380934,
     "wof:geomhash":"869390606e58df40b757efb59c92621e",
@@ -64,7 +72,7 @@
         }
     ],
     "wof:id":1158863249,
-    "wof:lastmodified":1694497822,
+    "wof:lastmodified":1695886600,
     "wof:name":"Taber",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/325/1/1158863251.geojson
+++ b/data/115/886/325/1/1158863251.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"314",
+        "can-abog:pid":"29882"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380935,
     "wof:geomhash":"101ec95854c1d6496e1771158d7b3824",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863251,
-    "wof:lastmodified":1694498042,
+    "wof:lastmodified":1695886452,
     "wof:name":"Thorhild",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/325/3/1158863253.geojson
+++ b/data/115/886/325/3/1158863253.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"323",
+        "can-abog:pid":"29883"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380935,
     "wof:geomhash":"a645a955711b5ad139faf29471f3238c",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863253,
-    "wof:lastmodified":1694498042,
+    "wof:lastmodified":1695886452,
     "wof:name":"Two Hills No. 21",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/325/5/1158863255.geojson
+++ b/data/115/886/325/5/1158863255.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"329",
+        "can-abog:pid":"29892"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380935,
     "wof:geomhash":"78b0a447104642d7d9b1d5f566b3c4a3",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863255,
-    "wof:lastmodified":1694498043,
+    "wof:lastmodified":1695886453,
     "wof:name":"Vermilion River",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/325/7/1158863257.geojson
+++ b/data/115/886/325/7/1158863257.geojson
@@ -115,6 +115,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"334",
+        "can-abog:pid":"29885"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380937,
     "wof:geomhash":"fdc2985c959a52d68b1098bc98608981",
@@ -127,7 +135,7 @@
         }
     ],
     "wof:id":1158863257,
-    "wof:lastmodified":1694497823,
+    "wof:lastmodified":1695886601,
     "wof:name":"Vulcan",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/325/9/1158863259.geojson
+++ b/data/115/886/325/9/1158863259.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"336",
+        "can-abog:pid":"29878"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380938,
     "wof:geomhash":"4fd42d24cb81368d37de05be642e65ff",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863259,
-    "wof:lastmodified":1694498043,
+    "wof:lastmodified":1695886454,
     "wof:name":"Wainwright No. 61",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/326/1/1158863261.geojson
+++ b/data/115/886/326/1/1158863261.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"340",
+        "can-abog:pid":"29887"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380939,
     "wof:geomhash":"0df8c60289475c3fe5be92f8e47ba3f1",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863261,
-    "wof:lastmodified":1694498043,
+    "wof:lastmodified":1695886454,
     "wof:name":"Warner No. 5",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/326/3/1158863263.geojson
+++ b/data/115/886/326/3/1158863263.geojson
@@ -73,6 +73,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"346",
+        "can-abog:pid":"29888"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380940,
     "wof:geomhash":"51f88ff104d23d528ba50efe1559bd5f",
@@ -85,7 +93,7 @@
         }
     ],
     "wof:id":1158863263,
-    "wof:lastmodified":1694497827,
+    "wof:lastmodified":1695886612,
     "wof:name":"Westlock",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/326/7/1158863267.geojson
+++ b/data/115/886/326/7/1158863267.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"348",
+        "can-abog:pid":"29889"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380941,
     "wof:geomhash":"938d746f62994823f78460a5d9e72539",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863267,
-    "wof:lastmodified":1694498043,
+    "wof:lastmodified":1695886454,
     "wof:name":"Wetaskiwin No. 10",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/326/9/1158863269.geojson
+++ b/data/115/886/326/9/1158863269.geojson
@@ -85,6 +85,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"349",
+        "can-abog:pid":"29890"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380941,
     "wof:geomhash":"7b52dbf5e283e5fb8834a6f87852b29d",
@@ -97,7 +105,7 @@
         }
     ],
     "wof:id":1158863269,
-    "wof:lastmodified":1694497827,
+    "wof:lastmodified":1695886610,
     "wof:name":"Wheatland",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/327/1/1158863271.geojson
+++ b/data/115/886/327/1/1158863271.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"353",
+        "can-abog:pid":"29912"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380943,
     "wof:geomhash":"7983b3d7591c82fa41ceddefe94ec539",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863271,
-    "wof:lastmodified":1694498043,
+    "wof:lastmodified":1695886455,
     "wof:name":"Willow Creek No. 26",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/327/3/1158863273.geojson
+++ b/data/115/886/327/3/1158863273.geojson
@@ -52,6 +52,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"361",
+        "can-abog:pid":"29942"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380944,
     "wof:geomhash":"1a7de527d2b2f8dbe19b588373bd6e1f",
@@ -64,7 +72,7 @@
         }
     ],
     "wof:id":1158863273,
-    "wof:lastmodified":1694497967,
+    "wof:lastmodified":1695886242,
     "wof:name":"Crowsnest Pass",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/327/5/1158863275.geojson
+++ b/data/115/886/327/5/1158863275.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"373",
+        "can-abog:pid":"29840"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380944,
     "wof:geomhash":"7f567588c837f8e54c21c36fe05f56e6",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863275,
-    "wof:lastmodified":1694498007,
+    "wof:lastmodified":1695886348,
     "wof:name":"Kananaskis",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/327/7/1158863277.geojson
+++ b/data/115/886/327/7/1158863277.geojson
@@ -64,6 +64,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"376",
+        "can-abog:pid":"29875"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380945,
     "wof:geomhash":"2bd7c980e55abb40c4618eaff04c996a",
@@ -76,7 +84,7 @@
         }
     ],
     "wof:id":1158863277,
-    "wof:lastmodified":1694497967,
+    "wof:lastmodified":1695886242,
     "wof:name":"Cypress",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/327/9/1158863279.geojson
+++ b/data/115/886/327/9/1158863279.geojson
@@ -109,6 +109,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"377",
+        "can-abog:pid":"29873"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380946,
     "wof:geomhash":"54fe4e66d6152c981fb7808dd7e8c871",
@@ -121,7 +129,7 @@
         }
     ],
     "wof:id":1158863279,
-    "wof:lastmodified":1694497824,
+    "wof:lastmodified":1695886605,
     "wof:name":"Clearwater",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/328/1/1158863281.geojson
+++ b/data/115/886/328/1/1158863281.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"382",
+        "can-abog:pid":"29867"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380948,
     "wof:geomhash":"79733751667ac2ef6cdfab07134dafb5",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863281,
-    "wof:lastmodified":1694497964,
+    "wof:lastmodified":1695886235,
     "wof:name":"Bighorn No. 8",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/328/5/1158863285.geojson
+++ b/data/115/886/328/5/1158863285.geojson
@@ -52,6 +52,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"383",
+        "can-abog:pid":"29862"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380949,
     "wof:geomhash":"0d427bfd6f1fc2359e085770bf264ae1",
@@ -64,7 +72,7 @@
         }
     ],
     "wof:id":1158863285,
-    "wof:lastmodified":1694497825,
+    "wof:lastmodified":1695886608,
     "wof:name":"Brazeau",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/328/7/1158863287.geojson
+++ b/data/115/886/328/7/1158863287.geojson
@@ -181,6 +181,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"418",
+        "can-abog:pid":"29841"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380949,
     "wof:geomhash":"69f1c76d00dda5531802489178ceed9a",
@@ -193,7 +201,7 @@
         }
     ],
     "wof:id":1158863287,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886514,
     "wof:name":"Jasper",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/328/9/1158863289.geojson
+++ b/data/115/886/328/9/1158863289.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"464",
+        "can-abog:pid":"29909"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380950,
     "wof:geomhash":"c192bdbb508ea05ed1b35bbb75552297",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863289,
-    "wof:lastmodified":1694497964,
+    "wof:lastmodified":1695886233,
     "wof:name":"Special Areas No. 3",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/329/1/1158863291.geojson
+++ b/data/115/886/329/1/1158863291.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"465",
+        "can-abog:pid":"29910"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380950,
     "wof:geomhash":"74a175e43c85a66bc04066c34eb0ac1c",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863291,
-    "wof:lastmodified":1694497964,
+    "wof:lastmodified":1695886234,
     "wof:name":"Special Areas No. 4",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/329/3/1158863293.geojson
+++ b/data/115/886/329/3/1158863293.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"479",
+        "can-abog:pid":"29842"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380952,
     "wof:geomhash":"8ea1daed237a0c0d66ead6b6f69ead25",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863293,
-    "wof:lastmodified":1694497967,
+    "wof:lastmodified":1695886244,
     "wof:name":"I.D. No. 25 (Willmore Wilderness)",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/329/5/1158863295.geojson
+++ b/data/115/886/329/5/1158863295.geojson
@@ -76,6 +76,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"480",
+        "can-abog:pid":"29891"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380953,
     "wof:geomhash":"4b63c6bdc9998640457b8f6168415e02",
@@ -88,7 +96,7 @@
         }
     ],
     "wof:id":1158863295,
-    "wof:lastmodified":1694498044,
+    "wof:lastmodified":1695886457,
     "wof:name":"Woodlands",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/329/7/1158863297.geojson
+++ b/data/115/886/329/7/1158863297.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"481",
+        "can-abog:pid":"29913"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380954,
     "wof:geomhash":"f19801be81fe7285fe92f1fc7a6c9aa3",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863297,
-    "wof:lastmodified":1694498004,
+    "wof:lastmodified":1695886341,
     "wof:name":"Greenview No. 16",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/329/9/1158863299.geojson
+++ b/data/115/886/329/9/1158863299.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"482",
+        "can-abog:pid":"29901"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380956,
     "wof:geomhash":"4c6a65a6e9bff3b31e83cc96ef59064f",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863299,
-    "wof:lastmodified":1694497825,
+    "wof:lastmodified":1695886606,
     "wof:name":"Yellowhead",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/330/3/1158863303.geojson
+++ b/data/115/886/330/3/1158863303.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"496",
+        "can-abog:pid":"29876"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380960,
     "wof:geomhash":"2a2f58af3759169c81803ce2ca30445f",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863303,
-    "wof:lastmodified":1694498025,
+    "wof:lastmodified":1695886402,
     "wof:name":"Northern Sunrise",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/330/5/1158863305.geojson
+++ b/data/115/886/330/5/1158863305.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"501",
+        "can-abog:pid":"29893"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380961,
     "wof:geomhash":"832492e0a3ad627557d89acc1b65f4cc",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863305,
-    "wof:lastmodified":1694498184,
+    "wof:lastmodified":1695886535,
     "wof:name":"Ranchland No. 66",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/330/7/1158863307.geojson
+++ b/data/115/886/330/7/1158863307.geojson
@@ -61,6 +61,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"502",
+        "can-abog:pid":"29877"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380964,
     "wof:geomhash":"014871e269237ce632075ee027b8708b",
@@ -73,7 +81,7 @@
         }
     ],
     "wof:id":1158863307,
-    "wof:lastmodified":1694497964,
+    "wof:lastmodified":1695886236,
     "wof:name":"Birch Hills",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/330/9/1158863309.geojson
+++ b/data/115/886/330/9/1158863309.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"503",
+        "can-abog:pid":"29904"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380965,
     "wof:geomhash":"e871fd4e07cbde7c0b4e17433365d65e",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863309,
-    "wof:lastmodified":1694498035,
+    "wof:lastmodified":1695886432,
     "wof:name":"Saddle Hills",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/331/1/1158863311.geojson
+++ b/data/115/886/331/1/1158863311.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"504",
+        "can-abog:pid":"29874"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380965,
     "wof:geomhash":"d085ffc8e4432048c096a6910664323f",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863311,
-    "wof:lastmodified":1694497965,
+    "wof:lastmodified":1695886237,
     "wof:name":"Clear Hills",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/331/3/1158863313.geojson
+++ b/data/115/886/331/3/1158863313.geojson
@@ -133,6 +133,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"505",
+        "can-abog:pid":"29837"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380966,
     "wof:geomhash":"f8ebdbd3c408c24153a8e7a5f80c6dd2",
@@ -145,7 +153,7 @@
         }
     ],
     "wof:id":1158863313,
-    "wof:lastmodified":1694498094,
+    "wof:lastmodified":1695886491,
     "wof:name":"Mackenzie",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/331/5/1158863315.geojson
+++ b/data/115/886/331/5/1158863315.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"506",
+        "can-abog:pid":"29866"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380968,
     "wof:geomhash":"bcc5731da45807123878cbe8082d9bd9",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863315,
-    "wof:lastmodified":1694498004,
+    "wof:lastmodified":1695886339,
     "wof:name":"Big Lakes",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/331/7/1158863317.geojson
+++ b/data/115/886/331/7/1158863317.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"507",
+        "can-abog:pid":"29857"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380968,
     "wof:geomhash":"726daeeb0defe609296e3694dccd0e0b",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863317,
-    "wof:lastmodified":1694498023,
+    "wof:lastmodified":1695886397,
     "wof:name":"Lesser Slave River No. 124",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/332/1/1158863321.geojson
+++ b/data/115/886/332/1/1158863321.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"508",
+        "can-abog:pid":"29838"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380969,
     "wof:geomhash":"ef1d40c4303c2151c09affc036227579",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863321,
-    "wof:lastmodified":1694498043,
+    "wof:lastmodified":1695886455,
     "wof:name":"Wood Buffalo",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/332/3/1158863323.geojson
+++ b/data/115/886/332/3/1158863323.geojson
@@ -70,6 +70,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"511",
+        "can-abog:pid":"29870"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380970,
     "wof:geomhash":"8ab7608d23328f7d05a784074815a635",
@@ -82,7 +90,7 @@
         }
     ],
     "wof:id":1158863323,
-    "wof:lastmodified":1694497823,
+    "wof:lastmodified":1695886602,
     "wof:name":"Northern Lights",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/332/5/1158863325.geojson
+++ b/data/115/886/332/5/1158863325.geojson
@@ -49,6 +49,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"512",
+        "can-abog:pid":"29894"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380973,
     "wof:geomhash":"6158850a13843f060410968f4b536742",
@@ -61,7 +69,7 @@
         }
     ],
     "wof:id":1158863325,
-    "wof:lastmodified":1694498025,
+    "wof:lastmodified":1695886403,
     "wof:name":"Opportunity No. 17",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/332/7/1158863327.geojson
+++ b/data/115/886/332/7/1158863327.geojson
@@ -97,6 +97,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"4353",
+        "can-abog:pid":"29847"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380974,
     "wof:geomhash":"4e1e5fb0ce7ced34b0ea4577612c7757",
@@ -109,7 +117,7 @@
         }
     ],
     "wof:id":1158863327,
-    "wof:lastmodified":1694498094,
+    "wof:lastmodified":1695886492,
     "wof:name":"Lac La Biche",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/332/9/1158863329.geojson
+++ b/data/115/886/332/9/1158863329.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"4640",
+        "can-abog:pid":"30558"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380975,
     "wof:geomhash":"068e3c5f5ddc698875ede1d641b7db5e",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863329,
-    "wof:lastmodified":1694497962,
+    "wof:lastmodified":1695886228,
     "wof:name":"Special Areas No. 2",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/333/1/1158863331.geojson
+++ b/data/115/886/333/1/1158863331.geojson
@@ -43,6 +43,14 @@
         85682091
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-abog:geocode":"5411",
+        "can-abog:pid":"34603"
+    },
+    "wof:concordances_official":"can-abog:geocode",
+    "wof:concordances_official_alt":[
+        "can-abog:pid"
+    ],
     "wof:country":"CA",
     "wof:created":1511380976,
     "wof:geomhash":"1a97ecc0da86205286e034c0b921f563",
@@ -55,7 +63,7 @@
         }
     ],
     "wof:id":1158863331,
-    "wof:lastmodified":1694497968,
+    "wof:lastmodified":1695886245,
     "wof:name":"I.D. No. 349",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/115/886/859/1/1158868591.geojson
+++ b/data/115/886/859/1/1158868591.geojson
@@ -74,6 +74,14 @@
         85682117
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-databc:aa_id":"337",
+        "statcan:cduid":"5924"
+    },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1512762150,
     "wof:geom_alt":[
@@ -89,7 +97,7 @@
         }
     ],
     "wof:id":1158868591,
-    "wof:lastmodified":1694497891,
+    "wof:lastmodified":1695886414,
     "wof:name":"Strathcona",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/115/886/859/5/1158868595.geojson
+++ b/data/115/886/859/5/1158868595.geojson
@@ -107,6 +107,14 @@
         85682117
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "can-databc:aa_id":"361",
+        "statcan:cduid":"5957"
+    },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1512762158,
     "wof:geom_alt":[
@@ -122,7 +130,7 @@
         }
     ],
     "wof:id":1158868595,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886507,
     "wof:name":"Stikine",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/115/886/892/9/1158868929.geojson
+++ b/data/115/886/892/9/1158868929.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4609"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779080,
     "wof:geomhash":"0989266acfcf29b94f02eb48a0f1d43b",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868929,
-    "wof:lastmodified":1694498003,
+    "wof:lastmodified":1695886337,
     "wof:name":"Division No. 9",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/893/1/1158868931.geojson
+++ b/data/115/886/893/1/1158868931.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4621"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779081,
     "wof:geomhash":"1e5e203dd8e2673ccf802e49edf009ad",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868931,
-    "wof:lastmodified":1694497985,
+    "wof:lastmodified":1695886285,
     "wof:name":"Division No. 21",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/893/3/1158868933.geojson
+++ b/data/115/886/893/3/1158868933.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4608"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779081,
     "wof:geomhash":"f22565fa6fd267ed87cb7d9fc53356a3",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868933,
-    "wof:lastmodified":1694498000,
+    "wof:lastmodified":1695886329,
     "wof:name":"Division No. 8",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/893/7/1158868937.geojson
+++ b/data/115/886/893/7/1158868937.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4714"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779083,
     "wof:geomhash":"df5ce1cf94792da9f121c62d455058c9",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868937,
-    "wof:lastmodified":1694497977,
+    "wof:lastmodified":1695886267,
     "wof:name":"Division No. 14",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/893/9/1158868939.geojson
+++ b/data/115/886/893/9/1158868939.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4604"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779084,
     "wof:geomhash":"b16e7db1e148fd6d9893d9aa51131d4f",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868939,
-    "wof:lastmodified":1694497988,
+    "wof:lastmodified":1695886295,
     "wof:name":"Division No. 4",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/894/1/1158868941.geojson
+++ b/data/115/886/894/1/1158868941.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4611"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779085,
     "wof:geomhash":"15b709b43998bf7f293a1ae76e88b0fa",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868941,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886519,
     "wof:name":"Division No. 11",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/894/3/1158868943.geojson
+++ b/data/115/886/894/3/1158868943.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4716"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779085,
     "wof:geomhash":"1c8f403ee4246084fad58fa01264ae5c",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868943,
-    "wof:lastmodified":1694497980,
+    "wof:lastmodified":1695886273,
     "wof:name":"Division No. 16",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/894/5/1158868945.geojson
+++ b/data/115/886/894/5/1158868945.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4606"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779086,
     "wof:geomhash":"d2ad0bda789ce51742e4faf982d741d3",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868945,
-    "wof:lastmodified":1694497991,
+    "wof:lastmodified":1695886303,
     "wof:name":"Division No. 6",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/894/7/1158868947.geojson
+++ b/data/115/886/894/7/1158868947.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4707"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779087,
     "wof:geomhash":"4a2abf2447d7852a28ad4cae3a16aa73",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868947,
-    "wof:lastmodified":1694497995,
+    "wof:lastmodified":1695886314,
     "wof:name":"Division No. 7",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/894/9/1158868949.geojson
+++ b/data/115/886/894/9/1158868949.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4711"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779088,
     "wof:geomhash":"814eb440aa3bc6f51ada6bbebfa8722b",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868949,
-    "wof:lastmodified":1694497974,
+    "wof:lastmodified":1695886258,
     "wof:name":"Division No. 11",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/895/1/1158868951.geojson
+++ b/data/115/886/895/1/1158868951.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4603"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779089,
     "wof:geomhash":"6be8edd981a84fafdeed4cf10f980acb",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868951,
-    "wof:lastmodified":1694497988,
+    "wof:lastmodified":1695886294,
     "wof:name":"Division No. 3",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/895/5/1158868955.geojson
+++ b/data/115/886/895/5/1158868955.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4712"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779090,
     "wof:geomhash":"20b41e81e0a1e3faf71e36520cc678ea",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868955,
-    "wof:lastmodified":1694497974,
+    "wof:lastmodified":1695886260,
     "wof:name":"Division No. 12",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/895/7/1158868957.geojson
+++ b/data/115/886/895/7/1158868957.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4620"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779091,
     "wof:geomhash":"42a5e3fe5294c3f44b44d0d61ba90b5c",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868957,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886506,
     "wof:name":"Division No. 20",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/895/9/1158868959.geojson
+++ b/data/115/886/895/9/1158868959.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4713"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779092,
     "wof:geomhash":"f3181811e1a18729f2998eaaa2d99d36",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868959,
-    "wof:lastmodified":1694497976,
+    "wof:lastmodified":1695886265,
     "wof:name":"Division No. 13",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/896/1/1158868961.geojson
+++ b/data/115/886/896/1/1158868961.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4704"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779093,
     "wof:geomhash":"bcb35769479e6f0240ade2fb6dc655c5",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868961,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886517,
     "wof:name":"Division No. 4",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/896/3/1158868963.geojson
+++ b/data/115/886/896/3/1158868963.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4706"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779093,
     "wof:geomhash":"6a6908d18928c4e628864631008981eb",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868963,
-    "wof:lastmodified":1694497992,
+    "wof:lastmodified":1695886305,
     "wof:name":"Division No. 6",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/896/5/1158868965.geojson
+++ b/data/115/886/896/5/1158868965.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4614"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779095,
     "wof:geomhash":"fe8c97488669e6ad8ff05a406e953fdc",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868965,
-    "wof:lastmodified":1694497978,
+    "wof:lastmodified":1695886271,
     "wof:name":"Division No. 14",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/896/7/1158868967.geojson
+++ b/data/115/886/896/7/1158868967.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4701"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779095,
     "wof:geomhash":"27ca13ba7ca20dee1840ea729bb5c9f4",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868967,
-    "wof:lastmodified":1694497971,
+    "wof:lastmodified":1695886251,
     "wof:name":"Division No. 1",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/896/9/1158868969.geojson
+++ b/data/115/886/896/9/1158868969.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4715"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779096,
     "wof:geomhash":"04e2f10ec98c6b7958ce3cdd7b135add",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868969,
-    "wof:lastmodified":1694497978,
+    "wof:lastmodified":1695886271,
     "wof:name":"Division No. 15",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/897/3/1158868973.geojson
+++ b/data/115/886/897/3/1158868973.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4616"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779097,
     "wof:geomhash":"44f97dfec4cfd000f0e1e1d0453123a8",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868973,
-    "wof:lastmodified":1694497981,
+    "wof:lastmodified":1695886274,
     "wof:name":"Division No. 16",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/897/5/1158868975.geojson
+++ b/data/115/886/897/5/1158868975.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4718"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779103,
     "wof:geomhash":"085e79f44c80f5a650ba827404e667f7",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868975,
-    "wof:lastmodified":1694497983,
+    "wof:lastmodified":1695886279,
     "wof:name":"Division No. 18",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/897/7/1158868977.geojson
+++ b/data/115/886/897/7/1158868977.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4717"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779104,
     "wof:geomhash":"d465dd78cd52dfb4c11366855f9481d8",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868977,
-    "wof:lastmodified":1694497982,
+    "wof:lastmodified":1695886277,
     "wof:name":"Division No. 17",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/897/9/1158868979.geojson
+++ b/data/115/886/897/9/1158868979.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4708"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779104,
     "wof:geomhash":"ea45210b2d5e78f6ee3e1d0537a233e7",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868979,
-    "wof:lastmodified":1694498000,
+    "wof:lastmodified":1695886330,
     "wof:name":"Division No. 8",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/898/1/1158868981.geojson
+++ b/data/115/886/898/1/1158868981.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4709"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779106,
     "wof:geomhash":"5a204774ec8776978a01d078c0d6457d",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868981,
-    "wof:lastmodified":1694498003,
+    "wof:lastmodified":1695886337,
     "wof:name":"Division No. 9",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/898/3/1158868983.geojson
+++ b/data/115/886/898/3/1158868983.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4710"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779107,
     "wof:geomhash":"1126e73ad27e7b5bc4ccaa1a1816faea",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868983,
-    "wof:lastmodified":1694497973,
+    "wof:lastmodified":1695886255,
     "wof:name":"Division No. 10",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/898/5/1158868985.geojson
+++ b/data/115/886/898/5/1158868985.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4607"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779108,
     "wof:geomhash":"8eb7c9640a2f98274d233913c0d5b9fc",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868985,
-    "wof:lastmodified":1694497996,
+    "wof:lastmodified":1695886316,
     "wof:name":"Division No. 7",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/898/7/1158868987.geojson
+++ b/data/115/886/898/7/1158868987.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4703"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779109,
     "wof:geomhash":"f325c9ebce78b3bd70bb90cc01174879",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868987,
-    "wof:lastmodified":1694497989,
+    "wof:lastmodified":1695886296,
     "wof:name":"Division No. 3",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/899/1/1158868991.geojson
+++ b/data/115/886/899/1/1158868991.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4605"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779110,
     "wof:geomhash":"7a2790b7a474493e5e6d141939de6409",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868991,
-    "wof:lastmodified":1694497989,
+    "wof:lastmodified":1695886298,
     "wof:name":"Division No. 5",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/899/3/1158868993.geojson
+++ b/data/115/886/899/3/1158868993.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4705"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779111,
     "wof:geomhash":"debda8e0905c9193c2d4f6c2ad741244",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868993,
-    "wof:lastmodified":1694497991,
+    "wof:lastmodified":1695886302,
     "wof:name":"Division No. 5",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/899/5/1158868995.geojson
+++ b/data/115/886/899/5/1158868995.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4615"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779112,
     "wof:geomhash":"62ab8f9c2d37b0147ec4e4eab39f4ef9",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868995,
-    "wof:lastmodified":1694497981,
+    "wof:lastmodified":1695886275,
     "wof:name":"Division No. 15",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/899/7/1158868997.geojson
+++ b/data/115/886/899/7/1158868997.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4617"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779113,
     "wof:geomhash":"c8e537ff68f737ee97f610f93ec15f58",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868997,
-    "wof:lastmodified":1694497983,
+    "wof:lastmodified":1695886278,
     "wof:name":"Division No. 17",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/899/9/1158868999.geojson
+++ b/data/115/886/899/9/1158868999.geojson
@@ -46,6 +46,10 @@
         85682113
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4702"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779114,
     "wof:geomhash":"14c087926ed4c04d9f7329bb4ab5c3d2",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158868999,
-    "wof:lastmodified":1694497985,
+    "wof:lastmodified":1695886286,
     "wof:name":"Division No. 2",
     "wof:parent_id":85682113,
     "wof:placetype":"county",

--- a/data/115/886/900/1/1158869001.geojson
+++ b/data/115/886/900/1/1158869001.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4610"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779115,
     "wof:geomhash":"e0d2dfc60c7c01cbad55aed8cb086eca",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869001,
-    "wof:lastmodified":1694497972,
+    "wof:lastmodified":1695886253,
     "wof:name":"Division No. 10",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/900/3/1158869003.geojson
+++ b/data/115/886/900/3/1158869003.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4601"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779116,
     "wof:geomhash":"1d5a1b9fb3828b607b175998aa895f1f",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869003,
-    "wof:lastmodified":1694497971,
+    "wof:lastmodified":1695886250,
     "wof:name":"Division No. 1",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/900/5/1158869005.geojson
+++ b/data/115/886/900/5/1158869005.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1003"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779117,
     "wof:geomhash":"7d46ec42c0a75b63f0dcd2991eff2a1f",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869005,
-    "wof:lastmodified":1694497986,
+    "wof:lastmodified":1695886288,
     "wof:name":"Division No. 3",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/900/9/1158869009.geojson
+++ b/data/115/886/900/9/1158869009.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1001"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779119,
     "wof:geomhash":"bbd8501ecdaa91784edddbb3170c28b2",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869009,
-    "wof:lastmodified":1694497968,
+    "wof:lastmodified":1695886245,
     "wof:name":"Division No. 1",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/901/1/1158869011.geojson
+++ b/data/115/886/901/1/1158869011.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1004"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779121,
     "wof:geomhash":"a211c1c6c8242f2a5770a05d34d42949",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869011,
-    "wof:lastmodified":1694497989,
+    "wof:lastmodified":1695886297,
     "wof:name":"Division No. 4",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/901/3/1158869013.geojson
+++ b/data/115/886/901/3/1158869013.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1006"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779122,
     "wof:geomhash":"fb3aef40ddd0c2628a86827a8de19571",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869013,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886518,
     "wof:name":"Division No. 6",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/901/5/1158869015.geojson
+++ b/data/115/886/901/5/1158869015.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1008"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779123,
     "wof:geomhash":"464850acd118bec1fb3f40c0bd6dadf8",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869015,
-    "wof:lastmodified":1694497997,
+    "wof:lastmodified":1695886319,
     "wof:name":"Division No. 8",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/901/7/1158869017.geojson
+++ b/data/115/886/901/7/1158869017.geojson
@@ -265,6 +265,10 @@
         85682065
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1308"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779127,
     "wof:geomhash":"e3da08d5f36f88fe25b01c292c960d76",
@@ -277,7 +281,7 @@
         }
     ],
     "wof:id":1158869017,
-    "wof:lastmodified":1694497821,
+    "wof:lastmodified":1695886599,
     "wof:name":"Kent",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/115/886/901/9/1158869019.geojson
+++ b/data/115/886/901/9/1158869019.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1007"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779128,
     "wof:geomhash":"ddc1c5b93e7cff7aecb0bad75273596d",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869019,
-    "wof:lastmodified":1694497993,
+    "wof:lastmodified":1695886308,
     "wof:name":"Division No. 7",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/902/1/1158869021.geojson
+++ b/data/115/886/902/1/1158869021.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1005"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779130,
     "wof:geomhash":"fb96010c5580de5f4a5675a1bf2a6eed",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869021,
-    "wof:lastmodified":1694497990,
+    "wof:lastmodified":1695886300,
     "wof:name":"Division No. 5",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/902/3/1158869023.geojson
+++ b/data/115/886/902/3/1158869023.geojson
@@ -52,6 +52,10 @@
         85682065
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1302"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779132,
     "wof:geomhash":"719cbe0e9ec21839411d4eb5ed5b2a98",
@@ -64,7 +68,7 @@
         }
     ],
     "wof:id":1158869023,
-    "wof:lastmodified":1694498094,
+    "wof:lastmodified":1695886493,
     "wof:name":"Charlotte",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/115/886/902/7/1158869027.geojson
+++ b/data/115/886/902/7/1158869027.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1002"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779133,
     "wof:geomhash":"348bf802fe29772c30400294cb4d8d87",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869027,
-    "wof:lastmodified":1694497984,
+    "wof:lastmodified":1695886282,
     "wof:name":"Division No. 2",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/902/9/1158869029.geojson
+++ b/data/115/886/902/9/1158869029.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1011"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779135,
     "wof:geomhash":"24bde01c4488aa157109d82d65732222",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869029,
-    "wof:lastmodified":1694497975,
+    "wof:lastmodified":1695886262,
     "wof:name":"Division No. 11",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/903/1/1158869031.geojson
+++ b/data/115/886/903/1/1158869031.geojson
@@ -46,6 +46,10 @@
         85682067
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6103"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779136,
     "wof:geomhash":"4e61f1b7de717a386b10c13ca25372d6",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869031,
-    "wof:lastmodified":1694498035,
+    "wof:lastmodified":1695886431,
     "wof:name":"Region 3",
     "wof:parent_id":85682067,
     "wof:placetype":"county",

--- a/data/115/886/903/3/1158869033.geojson
+++ b/data/115/886/903/3/1158869033.geojson
@@ -46,6 +46,10 @@
         85682067
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6101"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779142,
     "wof:geomhash":"791252afadbca3e08625b1d854218f01",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869033,
-    "wof:lastmodified":1694498030,
+    "wof:lastmodified":1695886416,
     "wof:name":"Region 1",
     "wof:parent_id":85682067,
     "wof:placetype":"county",

--- a/data/115/886/903/5/1158869035.geojson
+++ b/data/115/886/903/5/1158869035.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4613"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779148,
     "wof:geomhash":"9fff1774ad94ca00430c78f8e993c06b",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869035,
-    "wof:lastmodified":1694497977,
+    "wof:lastmodified":1695886270,
     "wof:name":"Division No. 13",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/903/7/1158869037.geojson
+++ b/data/115/886/903/7/1158869037.geojson
@@ -46,6 +46,10 @@
         85682067
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6104"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779149,
     "wof:geomhash":"bbe797e4025995d6aaa8236bc60194f6",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869037,
-    "wof:lastmodified":1694498035,
+    "wof:lastmodified":1695886431,
     "wof:name":"Region 4",
     "wof:parent_id":85682067,
     "wof:placetype":"county",

--- a/data/115/886/903/9/1158869039.geojson
+++ b/data/115/886/903/9/1158869039.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4619"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779149,
     "wof:geomhash":"ec5ba6b3139a2cd77de1e2518f52fab8",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869039,
-    "wof:lastmodified":1694497983,
+    "wof:lastmodified":1695886280,
     "wof:name":"Division No. 19",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/904/1/1158869041.geojson
+++ b/data/115/886/904/1/1158869041.geojson
@@ -46,6 +46,10 @@
         85682067
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6106"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779150,
     "wof:geomhash":"1850b5b1f1a496320cde0957696f5469",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869041,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886529,
     "wof:name":"Region 6",
     "wof:parent_id":85682067,
     "wof:placetype":"county",

--- a/data/115/886/904/5/1158869045.geojson
+++ b/data/115/886/904/5/1158869045.geojson
@@ -51,6 +51,10 @@
         85682105
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6205"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779152,
     "wof:geomhash":"ffc43dd222ac1fdb1f70ef4d091c355b",
@@ -63,7 +67,7 @@
         }
     ],
     "wof:id":1158869045,
-    "wof:lastmodified":1694498015,
+    "wof:lastmodified":1695886374,
     "wof:name":"Kivalliq",
     "wof:parent_id":85682105,
     "wof:placetype":"county",

--- a/data/115/886/904/7/1158869047.geojson
+++ b/data/115/886/904/7/1158869047.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4622"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779159,
     "wof:geomhash":"6b206e52ea148693dd93383eacf47a80",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869047,
-    "wof:lastmodified":1694497986,
+    "wof:lastmodified":1695886288,
     "wof:name":"Division No. 22",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/904/9/1158869049.geojson
+++ b/data/115/886/904/9/1158869049.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4623"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779159,
     "wof:geomhash":"db5f6522234635fd27bc89760f23b252",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869049,
-    "wof:lastmodified":1694497988,
+    "wof:lastmodified":1695886293,
     "wof:name":"Division No. 23",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/905/1/1158869051.geojson
+++ b/data/115/886/905/1/1158869051.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4618"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779160,
     "wof:geomhash":"86d2afda33fb1a3fd95148ca318ba374",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869051,
-    "wof:lastmodified":1694497984,
+    "wof:lastmodified":1695886281,
     "wof:name":"Division No. 18",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/905/3/1158869053.geojson
+++ b/data/115/886/905/3/1158869053.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4612"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779160,
     "wof:geomhash":"6b959911101c046c6ca6312710feed3c",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869053,
-    "wof:lastmodified":1694497976,
+    "wof:lastmodified":1695886266,
     "wof:name":"Division No. 12",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/905/5/1158869055.geojson
+++ b/data/115/886/905/5/1158869055.geojson
@@ -46,6 +46,10 @@
         85682067
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6105"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779161,
     "wof:geomhash":"dd255e12c2d003aee136be5f3b286cda",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869055,
-    "wof:lastmodified":1694498036,
+    "wof:lastmodified":1695886432,
     "wof:name":"Region 5",
     "wof:parent_id":85682067,
     "wof:placetype":"county",

--- a/data/115/886/905/7/1158869057.geojson
+++ b/data/115/886/905/7/1158869057.geojson
@@ -46,6 +46,10 @@
         85682067
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6102"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779161,
     "wof:geomhash":"cdd580a72b37315c0ecaeceb5799d79f",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869057,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886525,
     "wof:name":"Region 2",
     "wof:parent_id":85682067,
     "wof:placetype":"county",

--- a/data/115/886/905/9/1158869059.geojson
+++ b/data/115/886/905/9/1158869059.geojson
@@ -46,6 +46,10 @@
         85682085
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"4602"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779162,
     "wof:geomhash":"6fc1d5ee75a48e179f168c163606756b",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869059,
-    "wof:lastmodified":1694497984,
+    "wof:lastmodified":1695886282,
     "wof:name":"Division No. 2",
     "wof:parent_id":85682085,
     "wof:placetype":"county",

--- a/data/115/886/906/3/1158869063.geojson
+++ b/data/115/886/906/3/1158869063.geojson
@@ -58,6 +58,10 @@
         1158869045
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6204"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779167,
     "wof:geom_alt":[
@@ -73,7 +77,7 @@
         }
     ],
     "wof:id":1158869063,
-    "wof:lastmodified":1694498026,
+    "wof:lastmodified":1695886406,
     "wof:name":"Qikiqtaaluk",
     "wof:parent_id":85682105,
     "wof:placetype":"county",

--- a/data/115/886/906/5/1158869065.geojson
+++ b/data/115/886/906/5/1158869065.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1010"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779203,
     "wof:geomhash":"76591d69b62dafb5f23179ab76186bca",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869065,
-    "wof:lastmodified":1694497972,
+    "wof:lastmodified":1695886254,
     "wof:name":"Division No. 10",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/906/7/1158869067.geojson
+++ b/data/115/886/906/7/1158869067.geojson
@@ -46,6 +46,10 @@
         85682123
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"1009"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779204,
     "wof:geomhash":"bce46f6940cdc60c415c832a959f5d3c",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158869067,
-    "wof:lastmodified":1694498001,
+    "wof:lastmodified":1695886333,
     "wof:name":"Division No. 9",
     "wof:parent_id":85682123,
     "wof:placetype":"county",

--- a/data/115/886/906/9/1158869069.geojson
+++ b/data/115/886/906/9/1158869069.geojson
@@ -52,6 +52,10 @@
         85682105
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"6208"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1512779208,
     "wof:geom_alt":[
@@ -67,7 +71,7 @@
         }
     ],
     "wof:id":1158869069,
-    "wof:lastmodified":1694498007,
+    "wof:lastmodified":1695886350,
     "wof:name":"Kitikmeot",
     "wof:parent_id":85682105,
     "wof:placetype":"county",

--- a/data/115/888/488/1/1158884881.geojson
+++ b/data/115/888/488/1/1158884881.geojson
@@ -94,6 +94,10 @@
         136251273
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"2437"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1513023427,
     "wof:geomhash":"30c87eea34eb0d21ed64d809dbb29833",
@@ -106,7 +110,7 @@
         }
     ],
     "wof:id":1158884881,
-    "wof:lastmodified":1694497827,
+    "wof:lastmodified":1695886612,
     "wof:name":"Francheville",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/115/888/488/5/1158884885.geojson
+++ b/data/115/888/488/5/1158884885.geojson
@@ -46,6 +46,10 @@
         136251273
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"2440"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1513023429,
     "wof:geomhash":"7c459cc85cd1f9b0b818d40a47119707",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158884885,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886529,
     "wof:name":"Les Sources",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/115/888/488/7/1158884887.geojson
+++ b/data/115/888/488/7/1158884887.geojson
@@ -46,6 +46,10 @@
         136251273
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "statcan:cduid":"2428"
+    },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1513023430,
     "wof:geomhash":"ac7adc8bf43be6ba0f460110881726ee",
@@ -58,7 +62,7 @@
         }
     ],
     "wof:id":1158884887,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886529,
     "wof:name":"Les Etchemins",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/151/179/978/9/1511799789.geojson
+++ b/data/151/179/978/9/1511799789.geojson
@@ -466,7 +466,7 @@
         }
     ],
     "wof:id":1511799789,
-    "wof:lastmodified":1694497845,
+    "wof:lastmodified":1695886278,
     "wof:name":"Calgary",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/151/179/979/1/1511799791.geojson
+++ b/data/151/179/979/1/1511799791.geojson
@@ -457,7 +457,7 @@
         }
     ],
     "wof:id":1511799791,
-    "wof:lastmodified":1694497845,
+    "wof:lastmodified":1695886278,
     "wof:name":"Edmonton",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/151/179/979/3/1511799793.geojson
+++ b/data/151/179/979/3/1511799793.geojson
@@ -129,7 +129,7 @@
         }
     ],
     "wof:id":1511799793,
-    "wof:lastmodified":1694497845,
+    "wof:lastmodified":1695886278,
     "wof:name":"Drumheller",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/151/179/979/7/1511799797.geojson
+++ b/data/151/179/979/7/1511799797.geojson
@@ -219,7 +219,7 @@
         }
     ],
     "wof:id":1511799797,
-    "wof:lastmodified":1694492431,
+    "wof:lastmodified":1695886277,
     "wof:name":"Fort Saskatchewan",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/151/179/979/9/1511799799.geojson
+++ b/data/151/179/979/9/1511799799.geojson
@@ -211,7 +211,7 @@
         }
     ],
     "wof:id":1511799799,
-    "wof:lastmodified":1694497845,
+    "wof:lastmodified":1695886277,
     "wof:name":"St. Albert",
     "wof:parent_id":85682091,
     "wof:placetype":"county",

--- a/data/856/330/41/85633041.geojson
+++ b/data/856/330/41/85633041.geojson
@@ -1290,6 +1290,7 @@
         "hasc:id":"CA",
         "icao:code":"C",
         "ioc:id":"CAN",
+        "iso:code":"CA",
         "itu:id":"CAN",
         "loc:id":"n79007233",
         "m49:code":"124",
@@ -1304,6 +1305,7 @@
         "wk:page":"Canada",
         "wmo:id":"CN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
     "wof:country_alpha3":"CAN",
     "wof:geom_alt":[
@@ -1330,7 +1332,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1694639580,
+    "wof:lastmodified":1695881241,
     "wof:name":"Canada",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/820/57/85682057.geojson
+++ b/data/856/820/57/85682057.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":135.714674,
-    "geom:area_square_m":1075317391181.719604,
+    "geom:area_square_m":1075317391181.757202,
     "geom:bbox":"-95.15374,41.676572,-74.320106,56.859364",
     "geom:latitude":50.071779,
     "geom:longitude":-85.830447,
@@ -662,12 +662,14 @@
         "gn:id":6093943,
         "gp:id":2344922,
         "hasc:id":"CA.ON",
+        "iso:code":"CA-ON",
         "iso:id":"CA-ON",
         "unlc:id":"CA-ON",
         "wd:id":"Q1904"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"71e3f2324bc0ddf49448131a5531293e",
+    "wof:geomhash":"9e3d7e56f2b297da8e2f92a5e6c4e666",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -686,7 +688,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863876,
+    "wof:lastmodified":1695884761,
     "wof:name":"Ontario",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/65/85682065.geojson
+++ b/data/856/820/65/85682065.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.038117,
-    "geom:area_square_m":76712410581.346252,
+    "geom:area_square_m":76712410581.342148,
     "geom:bbox":"-69.053466,44.569141,-63.778162,48.220575",
     "geom:latitude":46.64694,
     "geom:longitude":-66.33521,
@@ -580,12 +580,14 @@
         "gn:id":6087430,
         "gp:id":2344918,
         "hasc:id":"CA.NB",
+        "iso:code":"CA-NB",
         "iso:id":"CA-NB",
         "unlc:id":"CA-NB",
         "wd:id":"Q1965"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"131c0f5ad8981b589e10d362d06d420a",
+    "wof:geomhash":"cc2d80ca3a76364b8e2945f08ac45932",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -604,7 +606,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863881,
+    "wof:lastmodified":1695884717,
     "wof:name":"New Brunswick",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/67/85682067.geojson
+++ b/data/856/820/67/85682067.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":345.932182,
-    "geom:area_square_m":1604869739336.712891,
+    "geom:area_square_m":1604869739336.673828,
     "geom:bbox":"-141.00275,59.99812,-102.000499,79.12991",
     "geom:latitude":67.872871,
     "geom:longitude":-119.128892,
@@ -562,12 +562,14 @@
         "gn:id":6091069,
         "gp:id":2344920,
         "hasc:id":"CA.NT",
+        "iso:code":"CA-NT",
         "iso:id":"CA-NT",
         "unlc:id":"CA-NT",
         "wd:id":"Q2007"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"969a23f51ff4f9cd76ef1ed2650e3626",
+    "wof:geomhash":"b52bfc5d23eb8c1e89f1e2cb24b6ded4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -586,7 +588,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863877,
+    "wof:lastmodified":1695884719,
     "wof:name":"Northwest Territories",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/75/85682075.geojson
+++ b/data/856/820/75/85682075.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.072812,
-    "geom:area_square_m":61658520249.812241,
+    "geom:area_square_m":61658520249.810013,
     "geom:bbox":"-66.391035,43.395943,-59.693917,47.226082",
     "geom:latitude":45.164165,
     "geom:longitude":-63.280037,
@@ -595,12 +595,14 @@
         "gn:id":6091530,
         "gp:id":2344921,
         "hasc:id":"CA.NS",
+        "iso:code":"CA-NS",
         "iso:id":"CA-NS",
         "unlc:id":"CA-NS",
         "wd:id":"Q1952"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"80614ae58883ba7d9ecbbe3e7f2233d5",
+    "wof:geomhash":"915a33ada9ba97992c1fc89066a10d53",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -619,7 +621,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863879,
+    "wof:lastmodified":1695884720,
     "wof:name":"Nova Scotia",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/81/85682081.geojson
+++ b/data/856/820/81/85682081.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.774673,
-    "geom:area_square_m":6607862387.15451,
+    "geom:area_square_m":6607862387.154302,
     "geom:bbox":"-64.418152,45.946797,-61.98653,47.060444",
     "geom:latitude":46.383042,
     "geom:longitude":-63.256369,
@@ -564,12 +564,14 @@
         "gn:id":6113358,
         "gp:id":2344923,
         "hasc:id":"CA.PE",
+        "iso:code":"CA-PE",
         "iso:id":"CA-PE",
         "unlc:id":"CA-PE",
         "wd:id":"Q1979"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"737bd832e758d16ab86720d673e3623c",
+    "wof:geomhash":"22ec9fbd0560cc561b31f9424c2bdc87",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -588,7 +590,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863879,
+    "wof:lastmodified":1695884718,
     "wof:name":"Prince Edward Island",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/85/85682085.geojson
+++ b/data/856/820/85/85682085.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":91.189233,
-    "geom:area_square_m":647017535366.578369,
+    "geom:area_square_m":647017535366.577271,
     "geom:bbox":"-102.007611,48.998868,-88.990814,59.99926",
     "geom:latitude":54.929035,
     "geom:longitude":-97.435069,
@@ -600,12 +600,14 @@
         "gn:id":6065171,
         "gp:id":2344917,
         "hasc:id":"CA.MB",
+        "iso:code":"CA-MB",
         "iso:id":"CA-MB",
         "unlc:id":"CA-MB",
         "wd:id":"Q1948"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"36e446c40d5fd7a65a443751cb0e078f",
+    "wof:geomhash":"94a076cf025141b8345ac8d9036bc720",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -624,7 +626,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863881,
+    "wof:lastmodified":1695884718,
     "wof:name":"Manitoba",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/91/85682091.geojson
+++ b/data/856/820/91/85682091.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":93.597047,
-    "geom:area_square_m":660169611526.623901,
+    "geom:area_square_m":660169611526.651001,
     "geom:bbox":"-120.001384,48.996677,-110.004764,60.000422",
     "geom:latitude":55.168137,
     "geom:longitude":-114.513165,
@@ -612,12 +612,14 @@
         "gn:id":5883102,
         "gp:id":2344915,
         "hasc:id":"CA.AB",
+        "iso:code":"CA-AB",
         "iso:id":"CA-AB",
         "unlc:id":"CA-AB",
         "wd:id":"Q1951"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"b098b428adcf347f48a1059151857fba",
+    "wof:geomhash":"2d327c82ecce08a5d325fbaefb8c0243",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -636,7 +638,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863880,
+    "wof:lastmodified":1695884716,
     "wof:name":"Alberta",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/820/95/85682095.geojson
+++ b/data/856/820/95/85682095.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":87.600323,
-    "geom:area_square_m":480643960722.640198,
+    "geom:area_square_m":480643960722.621887,
     "geom:bbox":"-141.00198,59.998542,-123.810229,69.647689",
     "geom:latitude":63.630867,
     "geom:longitude":-135.513153,
@@ -538,15 +538,17 @@
         "gn:id":6185811,
         "gp:id":2344926,
         "hasc:id":"CA.YT",
+        "iso:code":"CA-YT",
         "iso:id":"CA-YT",
         "unlc:id":"CA-YT",
         "wd:id":"Q2009"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890457195
     ],
     "wof:country":"CA",
-    "wof:geomhash":"af6ddcd05b1e57aed3fa0c01587d91d8",
+    "wof:geomhash":"85232bd81240dc0ca64646b7d8e73c3a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -565,7 +567,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863875,
+    "wof:lastmodified":1695884760,
     "wof:name":"Yukon",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/13/85682113.geojson
+++ b/data/856/821/13/85682113.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":90.420983,
-    "geom:area_square_m":649580597024.726562,
+    "geom:area_square_m":649580597024.734009,
     "geom:bbox":"-110.006365,48.998854,-101.361908,59.99982",
     "geom:latitude":54.417196,
     "geom:longitude":-105.892466,
@@ -605,12 +605,14 @@
         "gn:id":6141242,
         "gp:id":2344925,
         "hasc:id":"CA.SK",
+        "iso:code":"CA-SK",
         "iso:id":"CA-SK",
         "unlc:id":"CA-SK",
         "wd:id":"Q1989"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"130092951289f10f703888d2ee575965",
+    "wof:geomhash":"fbbdaf936c23522380955093492c421c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -629,7 +631,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863890,
+    "wof:lastmodified":1695884761,
     "wof:name":"Saskatchewan",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/17/85682117.geojson
+++ b/data/856/821/17/85682117.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":136.446824,
-    "geom:area_square_m":974376733738.663574,
+    "geom:area_square_m":974376733738.661377,
     "geom:bbox":"-139.06111,48.224554,-114.053822,60.002048",
     "geom:latitude":54.654369,
     "geom:longitude":-124.834255,
@@ -605,12 +605,14 @@
         "gn:id":5909050,
         "gp:id":2344916,
         "hasc:id":"CA.BC",
+        "iso:code":"CA-BC",
         "iso:id":"CA-BC",
         "unlc:id":"CA-BC",
         "wd:id":"Q1974"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"851f714959dbfa6ffd9fd1e7a9dab5c6",
+    "wof:geomhash":"b195f08194992672494d485e3ab3ad12",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -629,7 +631,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863888,
+    "wof:lastmodified":1695884717,
     "wof:name":"British Columbia",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/856/821/23/85682123.geojson
+++ b/data/856/821/23/85682123.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":58.684019,
-    "geom:area_square_m":437086270489.938416,
+    "geom:area_square_m":437086270489.944641,
     "geom:bbox":"-67.821685,46.614834,-52.638016,60.377744",
     "geom:latitude":52.903524,
     "geom:longitude":-60.344619,
@@ -597,12 +597,14 @@
         "gn:id":6354959,
         "gp:id":2344919,
         "hasc:id":"CA.NF",
+        "iso:code":"CA-NL",
         "iso:id":"CA-NL",
         "unlc:id":"CA-NL",
         "wd:id":"Q2003"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CA",
-    "wof:geomhash":"62cba5015c6b626e8add9e198ed439a4",
+    "wof:geomhash":"f1d94469e45de2b25d51054e47cdf1af",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -621,7 +623,7 @@
         "iku",
         "ikt"
     ],
-    "wof:lastmodified":1690863889,
+    "wof:lastmodified":1695884717,
     "wof:name":"Newfoundland and Labrador",
     "wof:parent_id":85633041,
     "wof:placetype":"region",

--- a/data/890/456/055/890456055.geojson
+++ b/data/890/456/055/890456055.geojson
@@ -95,8 +95,10 @@
     "wof:concordances":{
         "gp:id":29375192,
         "qs_pg:id":220446,
+        "statcan:cduid":"1305",
         "wk:page":"Kings"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053009,
     "wof:geom_alt":[
@@ -112,7 +114,7 @@
         }
     ],
     "wof:id":890456055,
-    "wof:lastmodified":1694497859,
+    "wof:lastmodified":1695886321,
     "wof:name":"Kings",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/456/257/890456257.geojson
+++ b/data/890/456/257/890456257.geojson
@@ -60,8 +60,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375250,
-        "qs_pg:id":1290423
+        "qs_pg:id":1290423,
+        "statcan:cduid":"3502"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053024,
     "wof:geom_alt":[
@@ -77,7 +79,7 @@
         }
     ],
     "wof:id":890456257,
-    "wof:lastmodified":1694498026,
+    "wof:lastmodified":1695886405,
     "wof:name":"Prescott and Russell",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/297/890456297.geojson
+++ b/data/890/456/297/890456297.geojson
@@ -269,9 +269,11 @@
     "wof:concordances":{
         "gp:id":29375100,
         "qs_pg:id":225130,
+        "statcan:cduid":"2458",
         "wd:id":"Q139398",
         "wk:page":"Longueuil"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053027,
     "wof:geom_alt":[
@@ -287,7 +289,7 @@
         }
     ],
     "wof:id":890456297,
-    "wof:lastmodified":1694497870,
+    "wof:lastmodified":1695886355,
     "wof:name":"Longueuil",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/305/890456305.geojson
+++ b/data/890/456/305/890456305.geojson
@@ -162,9 +162,11 @@
     "wof:concordances":{
         "gp:id":29375081,
         "qs_pg:id":1290355,
+        "statcan:cduid":"2412",
         "wd:id":"Q142024",
         "wk:page":"Rivi\u00e8re-du-Loup"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053027,
     "wof:geom_alt":[
@@ -180,7 +182,7 @@
         }
     ],
     "wof:id":890456305,
-    "wof:lastmodified":1694497865,
+    "wof:lastmodified":1695886340,
     "wof:name":"Riviere-du-Loup",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/307/890456307.geojson
+++ b/data/890/456/307/890456307.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375134,
         "qs_pg:id":1290375,
+        "statcan:cduid":"2478",
         "wd:id":"Q1517938",
         "wk:page":"Les Laurentides Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053028,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890456307,
-    "wof:lastmodified":1694497854,
+    "wof:lastmodified":1695886304,
     "wof:name":"Les Laurentides",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/309/890456309.geojson
+++ b/data/890/456/309/890456309.geojson
@@ -214,8 +214,10 @@
     "wof:concordances":{
         "gp:id":29375163,
         "qs_pg:id":1290389,
+        "statcan:cduid":"3512",
         "wk:page":"Hastings"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053028,
     "wof:geom_alt":[
@@ -231,7 +233,7 @@
         }
     ],
     "wof:id":890456309,
-    "wof:lastmodified":1694498082,
+    "wof:lastmodified":1695886457,
     "wof:name":"Hastings",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/313/890456313.geojson
+++ b/data/890/456/313/890456313.geojson
@@ -68,8 +68,10 @@
     "wof:concordances":{
         "gp:id":29375243,
         "qs_pg:id":1290418,
+        "statcan:cduid":"3548",
         "wk:page":"Nipissing"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053028,
     "wof:geom_alt":[
@@ -85,7 +87,7 @@
         }
     ],
     "wof:id":890456313,
-    "wof:lastmodified":1694497862,
+    "wof:lastmodified":1695886329,
     "wof:name":"Nipissing",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/315/890456315.geojson
+++ b/data/890/456/315/890456315.geojson
@@ -116,8 +116,10 @@
     "wof:concordances":{
         "gp:id":29375242,
         "qs_pg:id":1290421,
+        "statcan:cduid":"3556",
         "wk:page":"Cochrane"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053028,
     "wof:geom_alt":[
@@ -133,7 +135,7 @@
         }
     ],
     "wof:id":890456315,
-    "wof:lastmodified":1694498084,
+    "wof:lastmodified":1695886463,
     "wof:name":"Cochrane",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/317/890456317.geojson
+++ b/data/890/456/317/890456317.geojson
@@ -143,8 +143,10 @@
     "wof:concordances":{
         "gp:id":29375181,
         "qs_pg:id":1291505,
+        "statcan:cduid":"1307",
         "wk:page":"Westmorland"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053028,
     "wof:geom_alt":[
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890456317,
-    "wof:lastmodified":1694497870,
+    "wof:lastmodified":1695886356,
     "wof:name":"Westmorland",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/456/339/890456339.geojson
+++ b/data/890/456/339/890456339.geojson
@@ -92,8 +92,10 @@
     "wof:concordances":{
         "gp:id":29375066,
         "qs_pg:id":1291318,
+        "statcan:cduid":"3543",
         "wk:page":"Simcoe"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053033,
     "wof:geom_alt":[
@@ -109,7 +111,7 @@
         }
     ],
     "wof:id":890456339,
-    "wof:lastmodified":1694497855,
+    "wof:lastmodified":1695886307,
     "wof:name":"Simcoe",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/341/890456341.geojson
+++ b/data/890/456/341/890456341.geojson
@@ -240,8 +240,10 @@
     "wof:concordances":{
         "gp:id":29375120,
         "qs_pg:id":1291425,
+        "statcan:cduid":"3525",
         "wk:page":"Hamilton"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101735515
     ],
@@ -260,7 +262,7 @@
         }
     ],
     "wof:id":890456341,
-    "wof:lastmodified":1694498084,
+    "wof:lastmodified":1695886463,
     "wof:name":"Hamilton",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/343/890456343.geojson
+++ b/data/890/456/343/890456343.geojson
@@ -113,8 +113,10 @@
     "wof:concordances":{
         "gp:id":29375178,
         "qs_pg:id":1291471,
+        "statcan:cduid":"3521",
         "wk:page":"Peel"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053038,
     "wof:geom_alt":[
@@ -130,7 +132,7 @@
         }
     ],
     "wof:id":890456343,
-    "wof:lastmodified":1694497870,
+    "wof:lastmodified":1695886358,
     "wof:name":"Peel",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/397/890456397.geojson
+++ b/data/890/456/397/890456397.geojson
@@ -93,9 +93,11 @@
     "wof:concordances":{
         "gp:id":29375035,
         "qs_pg:id":1320740,
+        "statcan:cduid":"2411",
         "wd:id":"Q1517282",
         "wk:page":"Les Basques RCM"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053043,
     "wof:geom_alt":[
@@ -111,7 +113,7 @@
         }
     ],
     "wof:id":890456397,
-    "wof:lastmodified":1694497856,
+    "wof:lastmodified":1695886309,
     "wof:name":"Les Basques",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/455/890456455.geojson
+++ b/data/890/456/455/890456455.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375093,
         "qs_pg:id":1290356,
+        "statcan:cduid":"2445",
         "wd:id":"Q1517596",
         "wk:page":"Memphr\u00e9magog Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053046,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890456455,
-    "wof:lastmodified":1694497859,
+    "wof:lastmodified":1695886321,
     "wof:name":"Memphremagog",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/457/890456457.geojson
+++ b/data/890/456/457/890456457.geojson
@@ -156,8 +156,10 @@
     "wof:concordances":{
         "gp:id":29375098,
         "qs_pg:id":1290357,
+        "statcan:cduid":"1306",
         "wk:page":"Albert"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053046,
     "wof:geom_alt":[
@@ -173,7 +175,7 @@
         }
     ],
     "wof:id":890456457,
-    "wof:lastmodified":1694497869,
+    "wof:lastmodified":1695886353,
     "wof:name":"Albert",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/456/459/890456459.geojson
+++ b/data/890/456/459/890456459.geojson
@@ -95,8 +95,10 @@
     "wof:concordances":{
         "gp:id":29375123,
         "qs_pg:id":1290371,
+        "statcan:cduid":"1101",
         "wk:page":"Kings"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053046,
     "wof:geom_alt":[
@@ -112,7 +114,7 @@
         }
     ],
     "wof:id":890456459,
-    "wof:lastmodified":1694497869,
+    "wof:lastmodified":1695886353,
     "wof:name":"Kings",
     "wof:parent_id":85682081,
     "wof:placetype":"county",

--- a/data/890/456/461/890456461.geojson
+++ b/data/890/456/461/890456461.geojson
@@ -60,8 +60,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375125,
-        "qs_pg:id":1290372
+        "qs_pg:id":1290372,
+        "statcan:cduid":"1205"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053046,
     "wof:geom_alt":[
@@ -77,7 +79,7 @@
         }
     ],
     "wof:id":890456461,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886528,
     "wof:name":"Annapolis",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/456/465/890456465.geojson
+++ b/data/890/456/465/890456465.geojson
@@ -269,8 +269,10 @@
     "wof:concordances":{
         "gp:id":29375126,
         "qs_pg:id":1290373,
+        "statcan:cduid":"1312",
         "wk:page":"Victoria"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053046,
     "wof:geom_alt":[
@@ -286,7 +288,7 @@
         }
     ],
     "wof:id":890456465,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886528,
     "wof:name":"Victoria",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/456/467/890456467.geojson
+++ b/data/890/456/467/890456467.geojson
@@ -95,9 +95,11 @@
     "wof:concordances":{
         "gp:id":29375135,
         "qs_pg:id":1290384,
+        "statcan:cduid":"2410",
         "wd:id":"Q1517260",
         "wk:page":"Rimouski-Neigette"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053046,
     "wof:geom_alt":[
@@ -113,7 +115,7 @@
         }
     ],
     "wof:id":890456467,
-    "wof:lastmodified":1694497868,
+    "wof:lastmodified":1695886350,
     "wof:name":"Rimouski-Neigette",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/469/890456469.geojson
+++ b/data/890/456/469/890456469.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375170,
         "qs_pg:id":1290390,
+        "statcan:cduid":"2462",
         "wd:id":"Q1908110",
         "wk:page":"Matawinie Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053047,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890456469,
-    "wof:lastmodified":1694497868,
+    "wof:lastmodified":1695886351,
     "wof:name":"Matawinie",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/471/890456471.geojson
+++ b/data/890/456/471/890456471.geojson
@@ -224,9 +224,11 @@
     "wof:concordances":{
         "gp:id":29375218,
         "qs_pg:id":1290410,
+        "statcan:cduid":"2436",
         "wd:id":"Q141980",
         "wk:page":"Shawinigan"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101737059
     ],
@@ -245,7 +247,7 @@
         }
     ],
     "wof:id":890456471,
-    "wof:lastmodified":1694498082,
+    "wof:lastmodified":1695886459,
     "wof:name":"Shawinigan",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/473/890456473.geojson
+++ b/data/890/456/473/890456473.geojson
@@ -149,8 +149,10 @@
     "wof:concordances":{
         "gp:id":29375220,
         "qs_pg:id":1290412,
+        "statcan:cduid":"3547",
         "wk:page":"Renfrew"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053047,
     "wof:geom_alt":[
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890456473,
-    "wof:lastmodified":1694497946,
+    "wof:lastmodified":1695886559,
     "wof:name":"Renfrew",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/475/890456475.geojson
+++ b/data/890/456/475/890456475.geojson
@@ -197,9 +197,11 @@
     "wof:concordances":{
         "gp:id":29375244,
         "qs_pg:id":1290422,
+        "statcan:cduid":"2484",
         "wd:id":"Q40990",
         "wk:page":"Pontiac"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053048,
     "wof:geom_alt":[
@@ -215,7 +217,7 @@
         }
     ],
     "wof:id":890456475,
-    "wof:lastmodified":1694498179,
+    "wof:lastmodified":1695886498,
     "wof:name":"Pontiac",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/477/890456477.geojson
+++ b/data/890/456/477/890456477.geojson
@@ -99,8 +99,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375251,
-        "qs_pg:id":1290424
+        "qs_pg:id":1290424,
+        "statcan:cduid":"3501"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053048,
     "wof:geom_alt":[
@@ -116,7 +118,7 @@
         }
     ],
     "wof:id":890456477,
-    "wof:lastmodified":1694497858,
+    "wof:lastmodified":1695886316,
     "wof:name":"Stormont, Dundas and Glengarry",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/483/890456483.geojson
+++ b/data/890/456/483/890456483.geojson
@@ -279,8 +279,10 @@
     "wof:concordances":{
         "gp:id":29375060,
         "qs_pg:id":1291307,
+        "statcan:cduid":"3530",
         "wk:page":"Waterloo"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053048,
     "wof:geom_alt":[
@@ -296,7 +298,7 @@
         }
     ],
     "wof:id":890456483,
-    "wof:lastmodified":1694497948,
+    "wof:lastmodified":1695886618,
     "wof:name":"Waterloo",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/485/890456485.geojson
+++ b/data/890/456/485/890456485.geojson
@@ -132,9 +132,11 @@
     "wof:concordances":{
         "gp:id":29375061,
         "qs_pg:id":1291331,
+        "statcan:cduid":"2472",
         "wd:id":"Q141943",
         "wk:page":"Deux-Montagnes, Quebec"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053048,
     "wof:geom_alt":[
@@ -150,7 +152,7 @@
         }
     ],
     "wof:id":890456485,
-    "wof:lastmodified":1694497857,
+    "wof:lastmodified":1695886313,
     "wof:name":"Deux-Montagnes",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/487/890456487.geojson
+++ b/data/890/456/487/890456487.geojson
@@ -173,10 +173,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"257",
         "gp:id":29375156,
         "qs_pg:id":1291444,
+        "statcan:cduid":"5917",
         "wk:page":"Capital"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053048,
     "wof:geom_alt":[
@@ -193,7 +199,7 @@
         }
     ],
     "wof:id":890456487,
-    "wof:lastmodified":1694497866,
+    "wof:lastmodified":1695886342,
     "wof:name":"Capital",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/456/489/890456489.geojson
+++ b/data/890/456/489/890456489.geojson
@@ -74,8 +74,10 @@
     "wof:concordances":{
         "gp:id":29375144,
         "qs_pg:id":1291445,
+        "statcan:cduid":"3538",
         "wk:page":"Lambton"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053048,
     "wof:geom_alt":[
@@ -91,7 +93,7 @@
         }
     ],
     "wof:id":890456489,
-    "wof:lastmodified":1694497867,
+    "wof:lastmodified":1695886347,
     "wof:name":"Lambton",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/491/890456491.geojson
+++ b/data/890/456/491/890456491.geojson
@@ -164,8 +164,10 @@
     "wof:concordances":{
         "gp:id":29375176,
         "qs_pg:id":1291460,
+        "statcan:cduid":"1209",
         "wk:page":"Halifax"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053049,
     "wof:geom_alt":[
@@ -181,7 +183,7 @@
         }
     ],
     "wof:id":890456491,
-    "wof:lastmodified":1694497860,
+    "wof:lastmodified":1695886322,
     "wof:name":"Halifax",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/456/493/890456493.geojson
+++ b/data/890/456/493/890456493.geojson
@@ -164,8 +164,10 @@
     "wof:concordances":{
         "gp:id":29375180,
         "qs_pg:id":1291472,
+        "statcan:cduid":"3518",
         "wk:page":"Durham"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053049,
     "wof:geom_alt":[
@@ -181,7 +183,7 @@
         }
     ],
     "wof:id":890456493,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886508,
     "wof:name":"Durham",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/495/890456495.geojson
+++ b/data/890/456/495/890456495.geojson
@@ -89,9 +89,11 @@
     "wof:concordances":{
         "gp:id":29375174,
         "qs_pg:id":1291481,
+        "statcan:cduid":"2495",
         "wd:id":"Q1511288",
         "wk:page":"La Haute-C\u00f4te-Nord Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053049,
     "wof:geom_alt":[
@@ -107,7 +109,7 @@
         }
     ],
     "wof:id":890456495,
-    "wof:lastmodified":1694497870,
+    "wof:lastmodified":1695886355,
     "wof:name":"La Haute-Cote-Nord",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/497/890456497.geojson
+++ b/data/890/456/497/890456497.geojson
@@ -317,8 +317,10 @@
     "wof:concordances":{
         "gp:id":29375175,
         "qs_pg:id":1291504,
+        "statcan:cduid":"2406",
         "wk:page":"Avignon"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053049,
     "wof:geom_alt":[
@@ -334,7 +336,7 @@
         }
     ],
     "wof:id":890456497,
-    "wof:lastmodified":1694497859,
+    "wof:lastmodified":1695886321,
     "wof:name":"Avignon",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/501/890456501.geojson
+++ b/data/890/456/501/890456501.geojson
@@ -215,9 +215,11 @@
     "wof:concordances":{
         "gp:id":29375051,
         "qs_pg:id":237968,
+        "statcan:cduid":"2405",
         "wd:id":"Q43746",
         "wk:page":"Bonaventure"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053050,
     "wof:geom_alt":[
@@ -233,7 +235,7 @@
         }
     ],
     "wof:id":890456501,
-    "wof:lastmodified":1694497964,
+    "wof:lastmodified":1695886234,
     "wof:name":"Bonaventure",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/513/890456513.geojson
+++ b/data/890/456/513/890456513.geojson
@@ -101,8 +101,10 @@
     "wof:concordances":{
         "gp:id":29375095,
         "qs_pg:id":1313352,
+        "statcan:cduid":"2455",
         "wk:page":"Rouville"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053051,
     "wof:geom_alt":[
@@ -118,7 +120,7 @@
         }
     ],
     "wof:id":890456513,
-    "wof:lastmodified":1694497870,
+    "wof:lastmodified":1695886357,
     "wof:name":"Rouville",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/529/890456529.geojson
+++ b/data/890/456/529/890456529.geojson
@@ -107,11 +107,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"205",
         "gp:id":29375236,
         "qs_pg:id":1316167,
+        "statcan:cduid":"5901",
         "wd:id":"Q1364011",
         "wk:page":"Regional District of East Kootenay"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053052,
     "wof:geom_alt":[
@@ -128,7 +134,7 @@
         }
     ],
     "wof:id":890456529,
-    "wof:lastmodified":1694497862,
+    "wof:lastmodified":1695886330,
     "wof:name":"East Kootenay",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/456/531/890456531.geojson
+++ b/data/890/456/531/890456531.geojson
@@ -196,9 +196,11 @@
     "wof:concordances":{
         "gp:id":29375238,
         "qs_pg:id":1316171,
+        "statcan:cduid":"3560",
         "wd:id":"Q993714",
         "wk:page":"Kenora"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053052,
     "wof:geom_alt":[
@@ -214,7 +216,7 @@
         }
     ],
     "wof:id":890456531,
-    "wof:lastmodified":1694497863,
+    "wof:lastmodified":1695886332,
     "wof:name":"Kenora",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/537/890456537.geojson
+++ b/data/890/456/537/890456537.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375259,
         "qs_pg:id":1320923,
+        "statcan:cduid":"2497",
         "wd:id":"Q763526",
         "wk:page":"Sept-Rivi\u00e8res Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053052,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890456537,
-    "wof:lastmodified":1694497862,
+    "wof:lastmodified":1695886330,
     "wof:name":"Sept-Rivieres--Caniapiscau",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/545/890456545.geojson
+++ b/data/890/456/545/890456545.geojson
@@ -63,8 +63,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375036,
-        "qs_pg:id":1320742
+        "qs_pg:id":1320742,
+        "statcan:cduid":"2483"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053053,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890456545,
-    "wof:lastmodified":1694498020,
+    "wof:lastmodified":1695886391,
     "wof:name":"La Vallee-de-la-Gatineau",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/569/890456569.geojson
+++ b/data/890/456/569/890456569.geojson
@@ -572,9 +572,11 @@
     "wof:concordances":{
         "gp:id":29375221,
         "qs_pg:id":503952,
+        "statcan:cduid":"3542",
         "wd:id":"Q42519",
         "wk:page":"Grey"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053055,
     "wof:geom_alt":[
@@ -590,7 +592,7 @@
         }
     ],
     "wof:id":890456569,
-    "wof:lastmodified":1694498081,
+    "wof:lastmodified":1695886454,
     "wof:name":"Grey",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/677/890456677.geojson
+++ b/data/890/456/677/890456677.geojson
@@ -77,8 +77,10 @@
     "wof:concordances":{
         "gp:id":29375145,
         "qs_pg:id":903218,
+        "statcan:cduid":"2488",
         "wk:page":"Abitibi"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053072,
     "wof:geom_alt":[
@@ -94,7 +96,7 @@
         }
     ],
     "wof:id":890456677,
-    "wof:lastmodified":1694497868,
+    "wof:lastmodified":1695886350,
     "wof:name":"Abitibi",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/797/890456797.geojson
+++ b/data/890/456/797/890456797.geojson
@@ -90,9 +90,11 @@
     "wof:concordances":{
         "gp:id":29375079,
         "qs_pg:id":379302,
+        "statcan:cduid":"2420",
         "wd:id":"Q1516974",
         "wk:page":"L'\u00cele-d'Orl\u00e9ans Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053085,
     "wof:geom_alt":[
@@ -108,7 +110,7 @@
         }
     ],
     "wof:id":890456797,
-    "wof:lastmodified":1694497854,
+    "wof:lastmodified":1695886304,
     "wof:name":"L'ele-d'Orleans",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/799/890456799.geojson
+++ b/data/890/456/799/890456799.geojson
@@ -62,8 +62,10 @@
     "wof:concordances":{
         "gp:id":29375114,
         "qs_pg:id":379349,
+        "statcan:cduid":"3522",
         "wk:page":"Dufferin"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053086,
     "wof:geom_alt":[
@@ -79,7 +81,7 @@
         }
     ],
     "wof:id":890456799,
-    "wof:lastmodified":1694497854,
+    "wof:lastmodified":1695886305,
     "wof:name":"Dufferin",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/801/890456801.geojson
+++ b/data/890/456/801/890456801.geojson
@@ -123,9 +123,11 @@
     "wof:concordances":{
         "gp:id":29375137,
         "qs_pg:id":379361,
+        "statcan:cduid":"2444",
         "wd:id":"Q142053",
         "wk:page":"Coaticook"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053086,
     "wof:geom_alt":[
@@ -141,7 +143,7 @@
         }
     ],
     "wof:id":890456801,
-    "wof:lastmodified":1694497870,
+    "wof:lastmodified":1695886355,
     "wof:name":"Coaticook",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/803/890456803.geojson
+++ b/data/890/456/803/890456803.geojson
@@ -131,8 +131,10 @@
     "wof:concordances":{
         "gp:id":29375139,
         "qs_pg:id":379362,
+        "statcan:cduid":"1201",
         "wk:page":"Shelburne"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053086,
     "wof:geom_alt":[
@@ -148,7 +150,7 @@
         }
     ],
     "wof:id":890456803,
-    "wof:lastmodified":1694498083,
+    "wof:lastmodified":1695886461,
     "wof:name":"Shelburne",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/456/807/890456807.geojson
+++ b/data/890/456/807/890456807.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375140,
         "qs_pg:id":379363,
+        "statcan:cduid":"2403",
         "wd:id":"Q1517648",
         "wk:page":"La C\u00f4te-de-Gasp\u00e9 Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053086,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890456807,
-    "wof:lastmodified":1694497868,
+    "wof:lastmodified":1695886350,
     "wof:name":"La Cote-de-Gaspe",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/809/890456809.geojson
+++ b/data/890/456/809/890456809.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375141,
         "qs_pg:id":379364,
+        "statcan:cduid":"2456",
         "wd:id":"Q1517613",
         "wk:page":"Le Haut-Richelieu Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053087,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890456809,
-    "wof:lastmodified":1694497869,
+    "wof:lastmodified":1695886352,
     "wof:name":"Le Haut-Richelieu",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/811/890456811.geojson
+++ b/data/890/456/811/890456811.geojson
@@ -402,8 +402,10 @@
     "wof:concordances":{
         "gp:id":29375152,
         "qs_pg:id":379392,
+        "statcan:cduid":"3531",
         "wk:page":"Perth"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053087,
     "wof:geom_alt":[
@@ -419,7 +421,7 @@
         }
     ],
     "wof:id":890456811,
-    "wof:lastmodified":1694497857,
+    "wof:lastmodified":1695886313,
     "wof:name":"Perth",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/813/890456813.geojson
+++ b/data/890/456/813/890456813.geojson
@@ -104,11 +104,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"18",
         "gp:id":29375153,
         "qs_pg:id":379393,
+        "statcan:cduid":"5941",
         "wd:id":"Q2938768",
         "wk:page":"Cariboo"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053087,
     "wof:geom_alt":[
@@ -125,7 +131,7 @@
         }
     ],
     "wof:id":890456813,
-    "wof:lastmodified":1694497867,
+    "wof:lastmodified":1695886345,
     "wof:name":"Cariboo",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/456/815/890456815.geojson
+++ b/data/890/456/815/890456815.geojson
@@ -101,10 +101,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"322",
         "gp:id":29375154,
         "qs_pg:id":379394,
+        "statcan:cduid":"5927",
         "wk:page":"Powell River"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053087,
     "wof:geom_alt":[
@@ -121,7 +127,7 @@
         }
     ],
     "wof:id":890456815,
-    "wof:lastmodified":1694498084,
+    "wof:lastmodified":1695886464,
     "wof:name":"Powell River",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/456/817/890456817.geojson
+++ b/data/890/456/817/890456817.geojson
@@ -69,8 +69,10 @@
     "wof:concordances":{
         "gp:id":29375166,
         "qs_pg:id":379410,
+        "statcan:cduid":"2414",
         "wk:page":"Kamouraska"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053087,
     "wof:geom_alt":[
@@ -86,7 +88,7 @@
         }
     ],
     "wof:id":890456817,
-    "wof:lastmodified":1694497859,
+    "wof:lastmodified":1695886319,
     "wof:name":"Kamouraska",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/819/890456819.geojson
+++ b/data/890/456/819/890456819.geojson
@@ -284,8 +284,10 @@
     "wof:concordances":{
         "gp:id":29375167,
         "qs_pg:id":379411,
+        "statcan:cduid":"1204",
         "wk:page":"Queens"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053087,
     "wof:geom_alt":[
@@ -301,7 +303,7 @@
         }
     ],
     "wof:id":890456819,
-    "wof:lastmodified":1694497859,
+    "wof:lastmodified":1695886319,
     "wof:name":"Queens",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/456/821/890456821.geojson
+++ b/data/890/456/821/890456821.geojson
@@ -128,9 +128,11 @@
     "wof:concordances":{
         "gp:id":29375168,
         "qs_pg:id":379412,
+        "statcan:cduid":"2408",
         "wd:id":"Q142029",
         "wk:page":"Matane"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053088,
     "wof:geom_alt":[
@@ -146,7 +148,7 @@
         }
     ],
     "wof:id":890456821,
-    "wof:lastmodified":1694497859,
+    "wof:lastmodified":1695886321,
     "wof:name":"Matane",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/825/890456825.geojson
+++ b/data/890/456/825/890456825.geojson
@@ -89,8 +89,10 @@
     "wof:concordances":{
         "gp:id":29375169,
         "qs_pg:id":379413,
+        "statcan:cduid":"3529",
         "wk:page":"Brant"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053088,
     "wof:geom_alt":[
@@ -106,7 +108,7 @@
         }
     ],
     "wof:id":890456825,
-    "wof:lastmodified":1694497867,
+    "wof:lastmodified":1695886345,
     "wof:name":"Brant",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/827/890456827.geojson
+++ b/data/890/456/827/890456827.geojson
@@ -464,8 +464,10 @@
     "wof:concordances":{
         "gp:id":29375207,
         "qs_pg:id":379440,
+        "statcan:cduid":"3523",
         "wk:page":"Wellington"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053088,
     "wof:geom_alt":[
@@ -481,7 +483,7 @@
         }
     ],
     "wof:id":890456827,
-    "wof:lastmodified":1694497856,
+    "wof:lastmodified":1695886310,
     "wof:name":"Wellington",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/829/890456829.geojson
+++ b/data/890/456/829/890456829.geojson
@@ -153,10 +153,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"329",
         "gp:id":29375208,
         "qs_pg:id":379441,
+        "statcan:cduid":"5929",
         "wk:page":"Sunshine Coast"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053088,
     "wof:geom_alt":[
@@ -173,7 +179,7 @@
         }
     ],
     "wof:id":890456829,
-    "wof:lastmodified":1694498083,
+    "wof:lastmodified":1695886459,
     "wof:name":"Sunshine Coast",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/456/831/890456831.geojson
+++ b/data/890/456/831/890456831.geojson
@@ -93,9 +93,11 @@
     "wof:concordances":{
         "gp:id":29375214,
         "qs_pg:id":379459,
+        "statcan:cduid":"2494",
         "wd:id":"Q584069",
         "wk:page":"Le Fjord-du-Saguenay Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053088,
     "wof:geom_alt":[
@@ -111,7 +113,7 @@
         }
     ],
     "wof:id":890456831,
-    "wof:lastmodified":1694497869,
+    "wof:lastmodified":1695886352,
     "wof:name":"Le Saguenay-et-son-Fjord",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/833/890456833.geojson
+++ b/data/890/456/833/890456833.geojson
@@ -137,9 +137,11 @@
     "wof:concordances":{
         "gp:id":29375215,
         "qs_pg:id":379460,
+        "statcan:cduid":"2474",
         "wd:id":"Q141921",
         "wk:page":"Mirabel, Quebec"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101738507
     ],
@@ -158,7 +160,7 @@
         }
     ],
     "wof:id":890456833,
-    "wof:lastmodified":1694497948,
+    "wof:lastmodified":1695886621,
     "wof:name":"Mirabel",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/835/890456835.geojson
+++ b/data/890/456/835/890456835.geojson
@@ -92,9 +92,11 @@
     "wof:concordances":{
         "gp:id":29375217,
         "qs_pg:id":379461,
+        "statcan:cduid":"2457",
         "wd:id":"Q1517930",
         "wk:page":"La Vall\u00e9e-du-Richelieu Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053089,
     "wof:geom_alt":[
@@ -110,7 +112,7 @@
         }
     ],
     "wof:id":890456835,
-    "wof:lastmodified":1694497859,
+    "wof:lastmodified":1695886321,
     "wof:name":"La Vallee-du-Richelieu",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/837/890456837.geojson
+++ b/data/890/456/837/890456837.geojson
@@ -171,10 +171,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"301",
         "gp:id":29375223,
         "qs_pg:id":379473,
+        "statcan:cduid":"5943",
         "wk:page":"Mount Waddington"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053089,
     "wof:geom_alt":[
@@ -191,7 +197,7 @@
         }
     ],
     "wof:id":890456837,
-    "wof:lastmodified":1694498085,
+    "wof:lastmodified":1695886466,
     "wof:name":"Mount Waddington",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/456/839/890456839.geojson
+++ b/data/890/456/839/890456839.geojson
@@ -173,9 +173,11 @@
     "wof:concordances":{
         "gp:id":29375225,
         "qs_pg:id":379474,
+        "statcan:cduid":"2490",
         "wd:id":"Q141769",
         "wk:page":"La Tuque, Quebec"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101737199
     ],
@@ -194,7 +196,7 @@
         }
     ],
     "wof:id":890456839,
-    "wof:lastmodified":1694497935,
+    "wof:lastmodified":1695886392,
     "wof:name":"La Tuque",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/843/890456843.geojson
+++ b/data/890/456/843/890456843.geojson
@@ -290,9 +290,11 @@
     "wof:concordances":{
         "gp:id":29375248,
         "qs_pg:id":379507,
+        "statcan:cduid":"2481",
         "wd:id":"Q141844",
         "wk:page":"Gatineau"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101738041
     ],
@@ -311,7 +313,7 @@
         }
     ],
     "wof:id":890456843,
-    "wof:lastmodified":1694498083,
+    "wof:lastmodified":1695886461,
     "wof:name":"Gatineau",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/845/890456845.geojson
+++ b/data/890/456/845/890456845.geojson
@@ -218,8 +218,10 @@
     "wof:concordances":{
         "gp:id":29375247,
         "qs_pg:id":379514,
+        "statcan:cduid":"2476",
         "wk:page":"Argenteuil"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053090,
     "wof:geom_alt":[
@@ -235,7 +237,7 @@
         }
     ],
     "wof:id":890456845,
-    "wof:lastmodified":1694497857,
+    "wof:lastmodified":1695886316,
     "wof:name":"Argenteuil",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/847/890456847.geojson
+++ b/data/890/456/847/890456847.geojson
@@ -83,8 +83,10 @@
     "wof:concordances":{
         "gp:id":29375249,
         "qs_pg:id":379515,
+        "statcan:cduid":"2480",
         "wk:page":"Papineau"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053090,
     "wof:geom_alt":[
@@ -100,7 +102,7 @@
         }
     ],
     "wof:id":890456847,
-    "wof:lastmodified":1694497865,
+    "wof:lastmodified":1695886340,
     "wof:name":"Papineau",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/849/890456849.geojson
+++ b/data/890/456/849/890456849.geojson
@@ -102,9 +102,11 @@
     "wof:concordances":{
         "gp:id":29375255,
         "qs_pg:id":379530,
+        "statcan:cduid":"2498",
         "wd:id":"Q1517634",
         "wk:page":"Minganie Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053091,
     "wof:geom_alt":[
@@ -120,7 +122,7 @@
         }
     ],
     "wof:id":890456849,
-    "wof:lastmodified":1694497865,
+    "wof:lastmodified":1695886341,
     "wof:name":"Minganie--Le Golfe-du-Saint-Laurent",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/456/953/890456953.geojson
+++ b/data/890/456/953/890456953.geojson
@@ -98,11 +98,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"142",
         "gp:id":29375187,
         "qs_pg:id":988473,
+        "statcan:cduid":"5931",
         "wd:id":"Q132115",
         "wk:page":"Squamish-Lillooet Regional District"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053109,
     "wof:geom_alt":[
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":890456953,
-    "wof:lastmodified":1694498042,
+    "wof:lastmodified":1695886451,
     "wof:name":"Squamish-Lillooet",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/456/971/890456971.geojson
+++ b/data/890/456/971/890456971.geojson
@@ -80,8 +80,10 @@
     "wof:concordances":{
         "gp:id":29375261,
         "qs_pg:id":411223,
+        "statcan:cduid":"3559",
         "wk:page":"Rainy River"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053111,
     "wof:geom_alt":[
@@ -97,7 +99,7 @@
         }
     ],
     "wof:id":890456971,
-    "wof:lastmodified":1694497861,
+    "wof:lastmodified":1695886326,
     "wof:name":"Rainy River",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/456/991/890456991.geojson
+++ b/data/890/456/991/890456991.geojson
@@ -173,8 +173,10 @@
     "wof:concordances":{
         "gp:id":29375033,
         "qs_pg:id":40730,
+        "statcan:cduid":"3526",
         "wk:page":"Niagara"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053112,
     "wof:geom_alt":[
@@ -190,7 +192,7 @@
         }
     ],
     "wof:id":890456991,
-    "wof:lastmodified":1694498082,
+    "wof:lastmodified":1695886459,
     "wof:name":"Niagara",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/059/890457059.geojson
+++ b/data/890/457/059/890457059.geojson
@@ -107,8 +107,10 @@
     "wof:concordances":{
         "gp:id":29375204,
         "qs_pg:id":427037,
+        "statcan:cduid":"2449",
         "wk:page":"Drummond"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053116,
     "wof:geom_alt":[
@@ -124,7 +126,7 @@
         }
     ],
     "wof:id":890457059,
-    "wof:lastmodified":1694497890,
+    "wof:lastmodified":1695886409,
     "wof:name":"Drummond",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/171/890457171.geojson
+++ b/data/890/457/171/890457171.geojson
@@ -139,9 +139,11 @@
     "wof:concordances":{
         "gn:id":6691321,
         "qs_pg:id":643953,
+        "statcan:cduid":"2401",
         "wd:id":"Q728139",
         "wk:page":"Gasp\u00e9sie\u2013\u00celes-de-la-Madeleine"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053123,
     "wof:geom_alt":[
@@ -157,7 +159,7 @@
         }
     ],
     "wof:id":890457171,
-    "wof:lastmodified":1694497890,
+    "wof:lastmodified":1695886412,
     "wof:name":"Les Iles-de-la-Madeleine",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/185/890457185.geojson
+++ b/data/890/457/185/890457185.geojson
@@ -62,9 +62,11 @@
     "wof:concordances":{
         "gp:id":29375097,
         "qs_pg:id":890809,
+        "statcan:cduid":"3511",
         "wd:id":"Q3229493",
         "wk:page":"Lennox and Addington"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053124,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890457185,
-    "wof:lastmodified":1694497891,
+    "wof:lastmodified":1695886412,
     "wof:name":"Lennox and Addington",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/187/890457187.geojson
+++ b/data/890/457/187/890457187.geojson
@@ -71,8 +71,10 @@
     "wof:concordances":{
         "gp:id":29375110,
         "qs_pg:id":890810,
+        "statcan:cduid":"3546",
         "wk:page":"Haliburton"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053124,
     "wof:geom_alt":[
@@ -88,7 +90,7 @@
         }
     ],
     "wof:id":890457187,
-    "wof:lastmodified":1694497897,
+    "wof:lastmodified":1695886290,
     "wof:name":"Haliburton",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/189/890457189.geojson
+++ b/data/890/457/189/890457189.geojson
@@ -253,8 +253,10 @@
     "wof:concordances":{
         "gp:id":29375127,
         "qs_pg:id":890811,
+        "statcan:cduid":"1315",
         "wk:page":"Gloucester"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053124,
     "wof:geom_alt":[
@@ -270,7 +272,7 @@
         }
     ],
     "wof:id":890457189,
-    "wof:lastmodified":1694497883,
+    "wof:lastmodified":1695886394,
     "wof:name":"Gloucester",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/457/191/890457191.geojson
+++ b/data/890/457/191/890457191.geojson
@@ -113,9 +113,11 @@
     "wof:concordances":{
         "gp:id":29375111,
         "qs_pg:id":890822,
+        "statcan:cduid":"3549",
         "wd:id":"Q7139890",
         "wk:page":"Parry Sound"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053124,
     "wof:geom_alt":[
@@ -131,7 +133,7 @@
         }
     ],
     "wof:id":890457191,
-    "wof:lastmodified":1694498088,
+    "wof:lastmodified":1695886475,
     "wof:name":"Parry Sound",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/193/890457193.geojson
+++ b/data/890/457/193/890457193.geojson
@@ -87,11 +87,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"127",
         "gp:id":29375155,
         "qs_pg:id":890823,
+        "statcan:cduid":"5907",
         "wd:id":"Q3350017",
         "wk:page":"Okanagan\u2014Similkameen"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053124,
     "wof:geom_alt":[
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":890457193,
-    "wof:lastmodified":1694497872,
+    "wof:lastmodified":1695886361,
     "wof:name":"Okanagan-Similkameen",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/457/195/890457195.geojson
+++ b/data/890/457/195/890457195.geojson
@@ -360,8 +360,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375157,
-        "qs_pg:id":890824
+        "qs_pg:id":890824,
+        "statcan:cduid":"6001"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         85682095
     ],
@@ -380,7 +382,7 @@
         }
     ],
     "wof:id":890457195,
-    "wof:lastmodified":1694498088,
+    "wof:lastmodified":1695886473,
     "wof:name":"Yukon",
     "wof:parent_id":85682095,
     "wof:placetype":"county",

--- a/data/890/457/197/890457197.geojson
+++ b/data/890/457/197/890457197.geojson
@@ -167,8 +167,10 @@
     "wof:concordances":{
         "gp:id":29375193,
         "qs_pg:id":890825,
+        "statcan:cduid":"1211",
         "wk:page":"Cumberland"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053125,
     "wof:geom_alt":[
@@ -184,7 +186,7 @@
         }
     ],
     "wof:id":890457197,
-    "wof:lastmodified":1694498090,
+    "wof:lastmodified":1695886479,
     "wof:name":"Cumberland",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/457/199/890457199.geojson
+++ b/data/890/457/199/890457199.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375196,
         "qs_pg:id":890826,
+        "statcan:cduid":"2402",
         "wd:id":"Q1517681",
         "wk:page":"Le Rocher-Perc\u00e9 Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053125,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890457199,
-    "wof:lastmodified":1694497887,
+    "wof:lastmodified":1695886403,
     "wof:name":"Le Rocher-Perce",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/203/890457203.geojson
+++ b/data/890/457/203/890457203.geojson
@@ -89,9 +89,11 @@
     "wof:concordances":{
         "gp:id":29375197,
         "qs_pg:id":890827,
+        "statcan:cduid":"2479",
         "wd:id":"Q585440",
         "wk:page":"Antoine-Labelle Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053125,
     "wof:geom_alt":[
@@ -107,7 +109,7 @@
         }
     ],
     "wof:id":890457203,
-    "wof:lastmodified":1694497880,
+    "wof:lastmodified":1695886386,
     "wof:name":"Antoine-Labelle",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/205/890457205.geojson
+++ b/data/890/457/205/890457205.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375212,
         "qs_pg:id":890835,
+        "statcan:cduid":"2422",
         "wd:id":"Q1517325",
         "wk:page":"La Jacques-Cartier Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053126,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890457205,
-    "wof:lastmodified":1694497882,
+    "wof:lastmodified":1695886392,
     "wof:name":"La Jacques-Cartier",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/207/890457207.geojson
+++ b/data/890/457/207/890457207.geojson
@@ -176,10 +176,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"60",
         "gp:id":29375233,
         "qs_pg:id":890837,
+        "statcan:cduid":"5955",
         "wk:page":"Peace River"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053126,
     "wof:geom_alt":[
@@ -196,7 +202,7 @@
         }
     ],
     "wof:id":890457207,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886527,
     "wof:name":"Peace River",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/457/209/890457209.geojson
+++ b/data/890/457/209/890457209.geojson
@@ -101,10 +101,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"35",
         "gp:id":29375235,
         "qs_pg:id":890839,
+        "statcan:cduid":"5953",
         "wk:page":"Regional District of Fraser-Fort George"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053126,
     "wof:geom_alt":[
@@ -121,7 +127,7 @@
         }
     ],
     "wof:id":890457209,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886502,
     "wof:name":"Fraser-Fort George",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/457/225/890457225.geojson
+++ b/data/890/457/225/890457225.geojson
@@ -92,9 +92,11 @@
     "wof:concordances":{
         "gp:id":29375080,
         "qs_pg:id":897309,
+        "statcan:cduid":"2489",
         "wd:id":"Q575254",
         "wk:page":"La Vall\u00e9e-de-l'Or Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053127,
     "wof:geom_alt":[
@@ -110,7 +112,7 @@
         }
     ],
     "wof:id":890457225,
-    "wof:lastmodified":1694497888,
+    "wof:lastmodified":1695886407,
     "wof:name":"La Vallee-de-l'Or",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/241/890457241.geojson
+++ b/data/890/457/241/890457241.geojson
@@ -89,9 +89,11 @@
     "wof:concordances":{
         "gp:id":29375190,
         "qs_pg:id":900559,
+        "statcan:cduid":"2421",
         "wd:id":"Q1517234",
         "wk:page":"La C\u00f4te-de-Beaupr\u00e9 Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053128,
     "wof:geom_alt":[
@@ -107,7 +109,7 @@
         }
     ],
     "wof:id":890457241,
-    "wof:lastmodified":1694497887,
+    "wof:lastmodified":1695886403,
     "wof:name":"La Cete-de-Beaupre",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/247/890457247.geojson
+++ b/data/890/457/247/890457247.geojson
@@ -116,8 +116,10 @@
     "wof:concordances":{
         "gp:id":29375131,
         "qs_pg:id":903214,
+        "statcan:cduid":"3510",
         "wk:page":"Frontenac"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053129,
     "wof:geom_alt":[
@@ -133,7 +135,7 @@
         }
     ],
     "wof:id":890457247,
-    "wof:lastmodified":1694497887,
+    "wof:lastmodified":1695886404,
     "wof:name":"Frontenac",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/249/890457249.geojson
+++ b/data/890/457/249/890457249.geojson
@@ -101,11 +101,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"221",
         "gp:id":29375116,
         "qs_pg:id":903215,
+        "statcan:cduid":"5905",
         "wd:id":"Q2138253",
         "wk:page":"Regional District of Kootenay Boundary"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053129,
     "wof:geom_alt":[
@@ -122,7 +128,7 @@
         }
     ],
     "wof:id":890457249,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886526,
     "wof:name":"Kootenay Boundary",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/457/251/890457251.geojson
+++ b/data/890/457/251/890457251.geojson
@@ -141,8 +141,10 @@
     "wof:concordances":{
         "gp:id":29375122,
         "qs_pg:id":903217,
+        "statcan:cduid":"1303",
         "wk:page":"Sunbury"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053129,
     "wof:geom_alt":[
@@ -158,7 +160,7 @@
         }
     ],
     "wof:id":890457251,
-    "wof:lastmodified":1694498184,
+    "wof:lastmodified":1695886537,
     "wof:name":"Sunbury",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/457/277/890457277.geojson
+++ b/data/890/457/277/890457277.geojson
@@ -132,10 +132,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"274",
         "gp:id":29375186,
         "qs_pg:id":379421,
+        "statcan:cduid":"5945",
         "wk:page":"Central Coast"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053130,
     "wof:geom_alt":[
@@ -152,7 +158,7 @@
         }
     ],
     "wof:id":890457277,
-    "wof:lastmodified":1694498090,
+    "wof:lastmodified":1695886480,
     "wof:name":"Central Coast",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/457/465/890457465.geojson
+++ b/data/890/457/465/890457465.geojson
@@ -601,9 +601,11 @@
     "wof:concordances":{
         "gp:id":29375205,
         "qs_pg:id":988486,
+        "statcan:cduid":"3520",
         "wd:id":"Q172",
         "wk:page":"Toronto"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101735835
     ],
@@ -622,7 +624,7 @@
         }
     ],
     "wof:id":890457465,
-    "wof:lastmodified":1694497946,
+    "wof:lastmodified":1695886592,
     "wof:name":"Toronto",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/467/890457467.geojson
+++ b/data/890/457/467/890457467.geojson
@@ -107,11 +107,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"104",
         "gp:id":29375222,
         "qs_pg:id":988488,
+        "statcan:cduid":"5915",
         "wd:id":"Q5600798",
         "wk:page":"Greater Vancouver"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053140,
     "wof:geom_alt":[
@@ -128,7 +134,7 @@
         }
     ],
     "wof:id":890457467,
-    "wof:lastmodified":1694498023,
+    "wof:lastmodified":1695886397,
     "wof:name":"Greater Vancouver",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/457/469/890457469.geojson
+++ b/data/890/457/469/890457469.geojson
@@ -215,8 +215,10 @@
     "wof:concordances":{
         "gp:id":29375211,
         "qs_pg:id":988489,
+        "statcan:cduid":"3539",
         "wk:page":"Middlesex"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053141,
     "wof:geom_alt":[
@@ -232,7 +234,7 @@
         }
     ],
     "wof:id":890457469,
-    "wof:lastmodified":1694497889,
+    "wof:lastmodified":1695886408,
     "wof:name":"Middlesex",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/567/890457567.geojson
+++ b/data/890/457/567/890457567.geojson
@@ -62,9 +62,11 @@
     "wof:concordances":{
         "gp:id":29375072,
         "qs_pg:id":890798,
+        "statcan:cduid":"2450",
         "wd:id":"Q3341154",
         "wk:page":"Nicolet-Yamaska (electoral district)"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053148,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890457567,
-    "wof:lastmodified":1694497871,
+    "wof:lastmodified":1695886359,
     "wof:name":"Nicolet-Yamaska",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/569/890457569.geojson
+++ b/data/890/457/569/890457569.geojson
@@ -65,8 +65,10 @@
     "wof:concordances":{
         "gp:id":29375199,
         "qs_pg:id":890828,
+        "statcan:cduid":"2435",
         "wk:page":"M\u00e9kinac"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053148,
     "wof:geom_alt":[
@@ -82,7 +84,7 @@
         }
     ],
     "wof:id":890457569,
-    "wof:lastmodified":1694497871,
+    "wof:lastmodified":1695886359,
     "wof:name":"Mekinac",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/571/890457571.geojson
+++ b/data/890/457/571/890457571.geojson
@@ -92,9 +92,11 @@
     "wof:concordances":{
         "gp:id":29375200,
         "qs_pg:id":890829,
+        "statcan:cduid":"2407",
         "wd:id":"Q1798945",
         "wk:page":"La Matap\u00e9dia Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053148,
     "wof:geom_alt":[
@@ -110,7 +112,7 @@
         }
     ],
     "wof:id":890457571,
-    "wof:lastmodified":1694497890,
+    "wof:lastmodified":1695886410,
     "wof:name":"La Matapedia",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/573/890457573.geojson
+++ b/data/890/457/573/890457573.geojson
@@ -60,8 +60,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375201,
-        "qs_pg:id":890830
+        "qs_pg:id":890830,
+        "statcan:cduid":"3507"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053149,
     "wof:geom_alt":[
@@ -77,7 +79,7 @@
         }
     ],
     "wof:id":890457573,
-    "wof:lastmodified":1694498021,
+    "wof:lastmodified":1695886393,
     "wof:name":"Leeds and Grenville",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/575/890457575.geojson
+++ b/data/890/457/575/890457575.geojson
@@ -209,9 +209,11 @@
     "wof:concordances":{
         "gp:id":29375240,
         "qs_pg:id":890840,
+        "statcan:cduid":"2486",
         "wd:id":"Q141804",
         "wk:page":"Rouyn-Noranda"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101736943
     ],
@@ -230,7 +232,7 @@
         }
     ],
     "wof:id":890457575,
-    "wof:lastmodified":1694498088,
+    "wof:lastmodified":1695886475,
     "wof:name":"Rouyn-Noranda",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/577/890457577.geojson
+++ b/data/890/457/577/890457577.geojson
@@ -62,8 +62,10 @@
     "wof:concordances":{
         "gp:id":29375241,
         "qs_pg:id":890841,
+        "statcan:cduid":"2487",
         "wk:page":"Abitibi-Ouest"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053149,
     "wof:geom_alt":[
@@ -79,7 +81,7 @@
         }
     ],
     "wof:id":890457577,
-    "wof:lastmodified":1694497962,
+    "wof:lastmodified":1695886226,
     "wof:name":"Abitibi-Ouest",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/581/890457581.geojson
+++ b/data/890/457/581/890457581.geojson
@@ -740,9 +740,11 @@
     "wof:concordances":{
         "gp:id":29375185,
         "qs_pg:id":890842,
+        "statcan:cduid":"3541",
         "wd:id":"Q579371",
         "wk:page":"Bruce"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053149,
     "wof:geom_alt":[
@@ -758,7 +760,7 @@
         }
     ],
     "wof:id":890457581,
-    "wof:lastmodified":1694497884,
+    "wof:lastmodified":1695886396,
     "wof:name":"Bruce",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/691/890457691.geojson
+++ b/data/890/457/691/890457691.geojson
@@ -307,8 +307,10 @@
         "gn:id":6101646,
         "gp:id":29375059,
         "qs_pg:id":1081945,
+        "statcan:cduid":"3515",
         "wk:page":"Peterborough"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053155,
     "wof:geom_alt":[
@@ -324,7 +326,7 @@
         }
     ],
     "wof:id":890457691,
-    "wof:lastmodified":1694498179,
+    "wof:lastmodified":1695886497,
     "wof:name":"Peterborough",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/693/890457693.geojson
+++ b/data/890/457/693/890457693.geojson
@@ -199,8 +199,10 @@
         "gn:id":6050612,
         "gp:id":29375148,
         "qs_pg:id":1081946,
+        "statcan:cduid":"2465",
         "wk:page":"Laval"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101737759
     ],
@@ -219,7 +221,7 @@
         }
     ],
     "wof:id":890457693,
-    "wof:lastmodified":1694497946,
+    "wof:lastmodified":1695886587,
     "wof:name":"Laval",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/725/890457725.geojson
+++ b/data/890/457/725/890457725.geojson
@@ -389,9 +389,11 @@
     "wof:concordances":{
         "gp:id":29375043,
         "qs_pg:id":1089190,
+        "statcan:cduid":"1103",
         "wd:id":"Q2747456",
         "wk:page":"Prince"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053158,
     "wof:geom_alt":[
@@ -407,7 +409,7 @@
         }
     ],
     "wof:id":890457725,
-    "wof:lastmodified":1694497882,
+    "wof:lastmodified":1695886392,
     "wof:name":"Prince",
     "wof:parent_id":85682081,
     "wof:placetype":"county",

--- a/data/890/457/727/890457727.geojson
+++ b/data/890/457/727/890457727.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375044,
         "qs_pg:id":1089191,
+        "statcan:cduid":"2415",
         "wd:id":"Q1066730",
         "wk:page":"Charlevoix-Est Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053158,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890457727,
-    "wof:lastmodified":1694497890,
+    "wof:lastmodified":1695886412,
     "wof:name":"Charlevoix-Est",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/729/890457729.geojson
+++ b/data/890/457/729/890457729.geojson
@@ -63,8 +63,10 @@
     "wof:concordances":{
         "gp:id":29375045,
         "qs_pg:id":1089192,
+        "statcan:cduid":"1206",
         "wk:page":"Lunenburg"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053158,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890457729,
-    "wof:lastmodified":1694498022,
+    "wof:lastmodified":1695886395,
     "wof:name":"Lunenburg",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/457/731/890457731.geojson
+++ b/data/890/457/731/890457731.geojson
@@ -138,8 +138,10 @@
     "wof:concordances":{
         "gp:id":29375054,
         "qs_pg:id":1089193,
+        "statcan:cduid":"2467",
         "wk:page":"Roussillon"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053158,
     "wof:geom_alt":[
@@ -155,7 +157,7 @@
         }
     ],
     "wof:id":890457731,
-    "wof:lastmodified":1694497872,
+    "wof:lastmodified":1695886362,
     "wof:name":"Roussillon",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/733/890457733.geojson
+++ b/data/890/457/733/890457733.geojson
@@ -77,8 +77,10 @@
     "wof:concordances":{
         "gp:id":29375058,
         "qs_pg:id":1089194,
+        "statcan:cduid":"3513",
         "wk:page":"Prince Edward"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053164,
     "wof:geom_alt":[
@@ -94,7 +96,7 @@
         }
     ],
     "wof:id":890457733,
-    "wof:lastmodified":1694497886,
+    "wof:lastmodified":1695886401,
     "wof:name":"Prince Edward",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/735/890457735.geojson
+++ b/data/890/457/735/890457735.geojson
@@ -89,9 +89,11 @@
     "wof:concordances":{
         "gp:id":29375070,
         "qs_pg:id":1089195,
+        "statcan:cduid":"2409",
         "wd:id":"Q1517363",
         "wk:page":"La Mitis"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053164,
     "wof:geom_alt":[
@@ -107,7 +109,7 @@
         }
     ],
     "wof:id":890457735,
-    "wof:lastmodified":1694497887,
+    "wof:lastmodified":1695886403,
     "wof:name":"La Mitis",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/737/890457737.geojson
+++ b/data/890/457/737/890457737.geojson
@@ -284,8 +284,10 @@
     "wof:concordances":{
         "gp:id":29375085,
         "qs_pg:id":1089196,
+        "statcan:cduid":"1102",
         "wk:page":"Queens"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053164,
     "wof:geom_alt":[
@@ -301,7 +303,7 @@
         }
     ],
     "wof:id":890457737,
-    "wof:lastmodified":1694497871,
+    "wof:lastmodified":1695886360,
     "wof:name":"Queens",
     "wof:parent_id":85682081,
     "wof:placetype":"county",

--- a/data/890/457/739/890457739.geojson
+++ b/data/890/457/739/890457739.geojson
@@ -68,8 +68,10 @@
     "wof:concordances":{
         "gp:id":29375086,
         "qs_pg:id":1089197,
+        "statcan:cduid":"3554",
         "wk:page":"Timiskaming"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053164,
     "wof:geom_alt":[
@@ -85,7 +87,7 @@
         }
     ],
     "wof:id":890457739,
-    "wof:lastmodified":1694497871,
+    "wof:lastmodified":1695886359,
     "wof:name":"Timiskaming",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/743/890457743.geojson
+++ b/data/890/457/743/890457743.geojson
@@ -68,8 +68,10 @@
     "wof:concordances":{
         "gp:id":29375087,
         "qs_pg:id":1089198,
+        "statcan:cduid":"2434",
         "wk:page":"Portneuf"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053164,
     "wof:geom_alt":[
@@ -85,7 +87,7 @@
         }
     ],
     "wof:id":890457743,
-    "wof:lastmodified":1694497890,
+    "wof:lastmodified":1695886410,
     "wof:name":"Portneuf",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/745/890457745.geojson
+++ b/data/890/457/745/890457745.geojson
@@ -95,8 +95,10 @@
     "wof:concordances":{
         "gp:id":29375088,
         "qs_pg:id":1089199,
+        "statcan:cduid":"1207",
         "wk:page":"Kings"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053164,
     "wof:geom_alt":[
@@ -112,7 +114,7 @@
         }
     ],
     "wof:id":890457745,
-    "wof:lastmodified":1694497890,
+    "wof:lastmodified":1695886411,
     "wof:name":"Kings",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/457/747/890457747.geojson
+++ b/data/890/457/747/890457747.geojson
@@ -251,9 +251,11 @@
     "wof:concordances":{
         "gp:id":29375130,
         "qs_pg:id":1089200,
+        "statcan:cduid":"1217",
         "wd:id":"Q188489",
         "wk:page":"Cape Breton Island"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053165,
     "wof:geom_alt":[
@@ -269,7 +271,7 @@
         }
     ],
     "wof:id":890457747,
-    "wof:lastmodified":1694497885,
+    "wof:lastmodified":1695886398,
     "wof:name":"Cape Breton",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/457/749/890457749.geojson
+++ b/data/890/457/749/890457749.geojson
@@ -269,8 +269,10 @@
     "wof:concordances":{
         "gp:id":29375132,
         "qs_pg:id":1089201,
+        "statcan:cduid":"3514",
         "wk:page":"Northumberland"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053165,
     "wof:geom_alt":[
@@ -286,7 +288,7 @@
         }
     ],
     "wof:id":890457749,
-    "wof:lastmodified":1694497886,
+    "wof:lastmodified":1695886399,
     "wof:name":"Northumberland",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/755/890457755.geojson
+++ b/data/890/457/755/890457755.geojson
@@ -83,8 +83,10 @@
     "wof:concordances":{
         "gp:id":29375041,
         "qs_pg:id":1091597,
+        "statcan:cduid":"1313",
         "wk:page":"Madawaska"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053165,
     "wof:geom_alt":[
@@ -100,7 +102,7 @@
         }
     ],
     "wof:id":890457755,
-    "wof:lastmodified":1694497871,
+    "wof:lastmodified":1695886359,
     "wof:name":"Madawaska",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/457/801/890457801.geojson
+++ b/data/890/457/801/890457801.geojson
@@ -90,9 +90,11 @@
     "wof:concordances":{
         "gp:id":29375052,
         "qs_pg:id":1111190,
+        "statcan:cduid":"2459",
         "wd:id":"Q1517923",
         "wk:page":"Marguerite-D'Youville Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053168,
     "wof:geom_alt":[
@@ -108,7 +110,7 @@
         }
     ],
     "wof:id":890457801,
-    "wof:lastmodified":1694497890,
+    "wof:lastmodified":1695886411,
     "wof:name":"Lajemmerais",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/803/890457803.geojson
+++ b/data/890/457/803/890457803.geojson
@@ -63,8 +63,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375068,
-        "qs_pg:id":1111194
+        "qs_pg:id":1111194,
+        "statcan:cduid":"2432"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053168,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890457803,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886530,
     "wof:name":"L'erable",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/805/890457805.geojson
+++ b/data/890/457/805/890457805.geojson
@@ -92,8 +92,10 @@
     "wof:concordances":{
         "gp:id":29375083,
         "qs_pg:id":1111195,
+        "statcan:cduid":"1311",
         "wk:page":"Carleton"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053168,
     "wof:geom_alt":[
@@ -109,7 +111,7 @@
         }
     ],
     "wof:id":890457805,
-    "wof:lastmodified":1694497883,
+    "wof:lastmodified":1695886393,
     "wof:name":"Carleton",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/457/807/890457807.geojson
+++ b/data/890/457/807/890457807.geojson
@@ -284,8 +284,10 @@
     "wof:concordances":{
         "gp:id":29375084,
         "qs_pg:id":1111196,
+        "statcan:cduid":"1304",
         "wk:page":"Queens"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053168,
     "wof:geom_alt":[
@@ -301,7 +303,7 @@
         }
     ],
     "wof:id":890457807,
-    "wof:lastmodified":1694497889,
+    "wof:lastmodified":1695886407,
     "wof:name":"Queens",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/457/809/890457809.geojson
+++ b/data/890/457/809/890457809.geojson
@@ -98,9 +98,11 @@
     "wof:concordances":{
         "gp:id":29375103,
         "qs_pg:id":1111197,
+        "statcan:cduid":"2427",
         "wd:id":"Q3434815",
         "wk:page":"Robert Cliche"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053168,
     "wof:geom_alt":[
@@ -116,7 +118,7 @@
         }
     ],
     "wof:id":890457809,
-    "wof:lastmodified":1694497889,
+    "wof:lastmodified":1695886409,
     "wof:name":"Robert-Cliche",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/811/890457811.geojson
+++ b/data/890/457/811/890457811.geojson
@@ -62,8 +62,10 @@
     "wof:concordances":{
         "gp:id":29375109,
         "qs_pg:id":1111198,
+        "statcan:cduid":"2471",
         "wk:page":"Vaudreuil-Soulanges"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053168,
     "wof:geom_alt":[
@@ -79,7 +81,7 @@
         }
     ],
     "wof:id":890457811,
-    "wof:lastmodified":1694497879,
+    "wof:lastmodified":1695886383,
     "wof:name":"Vaudreuil-Soulanges",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/815/890457815.geojson
+++ b/data/890/457/815/890457815.geojson
@@ -95,8 +95,10 @@
     "wof:concordances":{
         "gp:id":29375133,
         "qs_pg:id":1111205,
+        "statcan:cduid":"2463",
         "wk:page":"Montcalm"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053169,
     "wof:geom_alt":[
@@ -112,7 +114,7 @@
         }
     ],
     "wof:id":890457815,
-    "wof:lastmodified":1694497888,
+    "wof:lastmodified":1695886406,
     "wof:name":"Montcalm",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/817/890457817.geojson
+++ b/data/890/457/817/890457817.geojson
@@ -63,8 +63,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375136,
-        "qs_pg:id":1111206
+        "qs_pg:id":1111206,
+        "statcan:cduid":"2469"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053169,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890457817,
-    "wof:lastmodified":1694498021,
+    "wof:lastmodified":1695886392,
     "wof:name":"Le Haut-Saint-Laurent",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/819/890457819.geojson
+++ b/data/890/457/819/890457819.geojson
@@ -84,9 +84,11 @@
     "wof:concordances":{
         "gp:id":29375138,
         "qs_pg:id":1111207,
+        "statcan:cduid":"2429",
         "wd:id":"Q813348",
         "wk:page":"Beauce-Sartigan Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053169,
     "wof:geom_alt":[
@@ -102,7 +104,7 @@
         }
     ],
     "wof:id":890457819,
-    "wof:lastmodified":1694497880,
+    "wof:lastmodified":1695886385,
     "wof:name":"Beauce-Sartigan",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/821/890457821.geojson
+++ b/data/890/457/821/890457821.geojson
@@ -68,8 +68,10 @@
     "wof:concordances":{
         "gp:id":29375160,
         "qs_pg:id":1111208,
+        "statcan:cduid":"2419",
         "wk:page":"Bellechasse"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053169,
     "wof:geom_alt":[
@@ -85,7 +87,7 @@
         }
     ],
     "wof:id":890457821,
-    "wof:lastmodified":1694497880,
+    "wof:lastmodified":1695886385,
     "wof:name":"Bellechasse",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/823/890457823.geojson
+++ b/data/890/457/823/890457823.geojson
@@ -65,9 +65,11 @@
     "wof:concordances":{
         "gp:id":29375165,
         "qs_pg:id":1111209,
+        "statcan:cduid":"2473",
         "wd:id":"Q16842973",
         "wk:page":"Th\u00e9r\u00e8se-De Blainville"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053170,
     "wof:geom_alt":[
@@ -83,7 +85,7 @@
         }
     ],
     "wof:id":890457823,
-    "wof:lastmodified":1694497887,
+    "wof:lastmodified":1695886404,
     "wof:name":"Thresce-De Blainville",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/825/890457825.geojson
+++ b/data/890/457/825/890457825.geojson
@@ -129,9 +129,11 @@
     "wof:concordances":{
         "gp:id":29375179,
         "qs_pg:id":1111210,
+        "statcan:cduid":"2460",
         "wd:id":"Q141754",
         "wk:page":"L'Assomption, Quebec"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053170,
     "wof:geom_alt":[
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":890457825,
-    "wof:lastmodified":1694497889,
+    "wof:lastmodified":1695886407,
     "wof:name":"L'Assomption",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/827/890457827.geojson
+++ b/data/890/457/827/890457827.geojson
@@ -92,9 +92,11 @@
     "wof:concordances":{
         "gp:id":29375183,
         "qs_pg:id":1111211,
+        "statcan:cduid":"2454",
         "wd:id":"Q1517861",
         "wk:page":"Les Maskoutains Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053170,
     "wof:geom_alt":[
@@ -110,7 +112,7 @@
         }
     ],
     "wof:id":890457827,
-    "wof:lastmodified":1694497879,
+    "wof:lastmodified":1695886383,
     "wof:name":"Les Maskoutains",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/829/890457829.geojson
+++ b/data/890/457/829/890457829.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375194,
         "qs_pg:id":1111212,
+        "statcan:cduid":"2426",
         "wd:id":"Q125495",
         "wk:page":"La Nouvelle-Beauce Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053171,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890457829,
-    "wof:lastmodified":1694497879,
+    "wof:lastmodified":1695886383,
     "wof:name":"La Nouvelle-Beauce",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/833/890457833.geojson
+++ b/data/890/457/833/890457833.geojson
@@ -65,9 +65,11 @@
     "wof:concordances":{
         "gp:id":29375195,
         "qs_pg:id":1111213,
+        "statcan:cduid":"2413",
         "wd:id":"Q3546770",
         "wk:page":"T\u00e9miscouata (electoral district)"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053171,
     "wof:geom_alt":[
@@ -83,7 +85,7 @@
         }
     ],
     "wof:id":890457833,
-    "wof:lastmodified":1694497882,
+    "wof:lastmodified":1695886392,
     "wof:name":"Temiscouata",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/835/890457835.geojson
+++ b/data/890/457/835/890457835.geojson
@@ -266,9 +266,11 @@
     "wof:concordances":{
         "gp:id":29375203,
         "qs_pg:id":1111214,
+        "statcan:cduid":"2443",
         "wd:id":"Q139473",
         "wk:page":"Sherbrooke"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101738289
     ],
@@ -287,7 +289,7 @@
         }
     ],
     "wof:id":890457835,
-    "wof:lastmodified":1694497934,
+    "wof:lastmodified":1695886392,
     "wof:name":"Sherbrooke",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/881/890457881.geojson
+++ b/data/890/457/881/890457881.geojson
@@ -274,11 +274,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"310",
         "gp:id":29375073,
         "qs_pg:id":1119930,
+        "statcan:cduid":"5921",
         "wd:id":"Q16461",
         "wk:page":"Nanaimo"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053174,
     "wof:geom_alt":[
@@ -295,7 +301,7 @@
         }
     ],
     "wof:id":890457881,
-    "wof:lastmodified":1694498088,
+    "wof:lastmodified":1695886474,
     "wof:name":"Nanaimo",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/457/887/890457887.geojson
+++ b/data/890/457/887/890457887.geojson
@@ -63,8 +63,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375182,
-        "qs_pg:id":1119938
+        "qs_pg:id":1119938,
+        "statcan:cduid":"2442"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053174,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890457887,
-    "wof:lastmodified":1694498179,
+    "wof:lastmodified":1695886497,
     "wof:name":"Le Val-Saint-Francois",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/889/890457889.geojson
+++ b/data/890/457/889/890457889.geojson
@@ -62,8 +62,10 @@
     "wof:concordances":{
         "gp:id":29375053,
         "qs_pg:id":1121291,
+        "statcan:cduid":"2446",
         "wk:page":"Brome-Missisquoi"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053174,
     "wof:geom_alt":[
@@ -79,7 +81,7 @@
         }
     ],
     "wof:id":890457889,
-    "wof:lastmodified":1694497965,
+    "wof:lastmodified":1695886237,
     "wof:name":"Brome-Missisquoi",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/891/890457891.geojson
+++ b/data/890/457/891/890457891.geojson
@@ -87,8 +87,10 @@
     "wof:concordances":{
         "gp:id":29375124,
         "qs_pg:id":1133733,
+        "statcan:cduid":"2418",
         "wk:page":"Montmagny"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053175,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890457891,
-    "wof:lastmodified":1694497890,
+    "wof:lastmodified":1695886410,
     "wof:name":"Montmagny",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/457/893/890457893.geojson
+++ b/data/890/457/893/890457893.geojson
@@ -95,8 +95,10 @@
     "wof:concordances":{
         "gp:id":29375191,
         "qs_pg:id":1133740,
+        "statcan:cduid":"3557",
         "wk:page":"Algoma"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053175,
     "wof:geom_alt":[
@@ -112,7 +114,7 @@
         }
     ],
     "wof:id":890457893,
-    "wof:lastmodified":1694497881,
+    "wof:lastmodified":1695886387,
     "wof:name":"Algoma",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/457/997/890457997.geojson
+++ b/data/890/457/997/890457997.geojson
@@ -119,8 +119,10 @@
     "wof:concordances":{
         "gp:id":29375147,
         "qs_pg:id":890817,
+        "statcan:cduid":"2496",
         "wk:page":"Manicouagan"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053180,
     "wof:geom_alt":[
@@ -136,7 +138,7 @@
         }
     ],
     "wof:id":890457997,
-    "wof:lastmodified":1694498179,
+    "wof:lastmodified":1695886499,
     "wof:name":"Manicouagan",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/001/890458001.geojson
+++ b/data/890/458/001/890458001.geojson
@@ -257,8 +257,10 @@
     "wof:concordances":{
         "gp:id":29375159,
         "qs_pg:id":890819,
+        "statcan:cduid":"1309",
         "wk:page":"Northumberland"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053181,
     "wof:geom_alt":[
@@ -274,7 +276,7 @@
         }
     ],
     "wof:id":890458001,
-    "wof:lastmodified":1694497850,
+    "wof:lastmodified":1695886293,
     "wof:name":"Northumberland",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/458/003/890458003.geojson
+++ b/data/890/458/003/890458003.geojson
@@ -175,9 +175,11 @@
     "wof:concordances":{
         "gp:id":29375161,
         "qs_pg:id":890820,
+        "statcan:cduid":"1214",
         "wd:id":"Q575483",
         "wk:page":"Antigonish, Nova Scotia"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053181,
     "wof:geom_alt":[
@@ -193,7 +195,7 @@
         }
     ],
     "wof:id":890458003,
-    "wof:lastmodified":1694498079,
+    "wof:lastmodified":1695886450,
     "wof:name":"Antigonish",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/005/890458005.geojson
+++ b/data/890/458/005/890458005.geojson
@@ -153,8 +153,10 @@
     "wof:concordances":{
         "gp:id":29375162,
         "qs_pg:id":890821,
+        "statcan:cduid":"1301",
         "wk:page":"Saint John"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053181,
     "wof:geom_alt":[
@@ -170,7 +172,7 @@
         }
     ],
     "wof:id":890458005,
-    "wof:lastmodified":1694498080,
+    "wof:lastmodified":1695886453,
     "wof:name":"Saint John",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/458/013/890458013.geojson
+++ b/data/890/458/013/890458013.geojson
@@ -263,8 +263,10 @@
     "wof:concordances":{
         "gp:id":29375082,
         "qs_pg:id":897310,
+        "statcan:cduid":"1215",
         "wk:page":"Inverness"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053181,
     "wof:geom_alt":[
@@ -280,7 +282,7 @@
         }
     ],
     "wof:id":890458013,
-    "wof:lastmodified":1694497848,
+    "wof:lastmodified":1695886286,
     "wof:name":"Inverness",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/017/890458017.geojson
+++ b/data/890/458/017/890458017.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375105,
         "qs_pg:id":897312,
+        "statcan:cduid":"2404",
         "wd:id":"Q1517912",
         "wk:page":"La Haute-Gasp\u00e9sie Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053182,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890458017,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886299,
     "wof:name":"La Haute-Gaspesie",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/019/890458019.geojson
+++ b/data/890/458/019/890458019.geojson
@@ -110,9 +110,11 @@
     "wof:concordances":{
         "gp:id":29375106,
         "qs_pg:id":897313,
+        "statcan:cduid":"3528",
         "wd:id":"Q385346",
         "wk:page":"Haldimand County"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053182,
     "wof:geom_alt":[
@@ -128,7 +130,7 @@
         }
     ],
     "wof:id":890458019,
-    "wof:lastmodified":1694498005,
+    "wof:lastmodified":1695886343,
     "wof:name":"Haldimand-Norfolk",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/021/890458021.geojson
+++ b/data/890/458/021/890458021.geojson
@@ -92,9 +92,11 @@
     "wof:concordances":{
         "gp:id":29375149,
         "qs_pg:id":897314,
+        "statcan:cduid":"2491",
         "wd:id":"Q1511248",
         "wk:page":"Le Domaine-du-Roy"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053182,
     "wof:geom_alt":[
@@ -110,7 +112,7 @@
         }
     ],
     "wof:id":890458021,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886299,
     "wof:name":"Le Domaine-du-Roy",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/025/890458025.geojson
+++ b/data/890/458/025/890458025.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375245,
         "qs_pg:id":897317,
+        "statcan:cduid":"2485",
         "wd:id":"Q1517559",
         "wk:page":"T\u00e9miscamingue Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053183,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890458025,
-    "wof:lastmodified":1694497848,
+    "wof:lastmodified":1695886287,
     "wof:name":"Temiscamingue",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/027/890458027.geojson
+++ b/data/890/458/027/890458027.geojson
@@ -80,9 +80,11 @@
     "wof:concordances":{
         "gp:id":29375246,
         "qs_pg:id":897318,
+        "statcan:cduid":"2482",
         "wd:id":"Q1451121",
         "wk:page":"Les Collines-de-l'Outaouais Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053183,
     "wof:geom_alt":[
@@ -98,7 +100,7 @@
         }
     ],
     "wof:id":890458027,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886297,
     "wof:name":"Les Collines-de-l'Outaouais",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/033/890458033.geojson
+++ b/data/890/458/033/890458033.geojson
@@ -470,8 +470,10 @@
     "wof:concordances":{
         "gp:id":29375121,
         "qs_pg:id":903213,
+        "statcan:cduid":"2423",
         "wk:page":"Quebec"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101737491
     ],
@@ -490,7 +492,7 @@
         }
     ],
     "wof:id":890458033,
-    "wof:lastmodified":1694497947,
+    "wof:lastmodified":1695886594,
     "wof:name":"Quebec",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/063/890458063.geojson
+++ b/data/890/458/063/890458063.geojson
@@ -78,9 +78,11 @@
     "wof:concordances":{
         "gp:id":29375234,
         "qs_pg:id":890838,
+        "statcan:cduid":"5959",
         "wd:id":"Q7058940",
         "wk:page":"Northern Rocky Mountains"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101741097
     ],
@@ -99,7 +101,7 @@
         }
     ],
     "wof:id":890458063,
-    "wof:lastmodified":1694498025,
+    "wof:lastmodified":1695886402,
     "wof:name":"Northern Rockies",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/081/890458081.geojson
+++ b/data/890/458/081/890458081.geojson
@@ -134,8 +134,10 @@
     "wof:concordances":{
         "gp:id":29375065,
         "qs_pg:id":1111191,
+        "statcan:cduid":"2448",
         "wk:page":"Acton"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053187,
     "wof:geom_alt":[
@@ -151,7 +153,7 @@
         }
     ],
     "wof:id":890458081,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886297,
     "wof:name":"Acton",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/085/890458085.geojson
+++ b/data/890/458/085/890458085.geojson
@@ -69,9 +69,11 @@
     "wof:concordances":{
         "gp:id":29375071,
         "qs_pg:id":890797,
+        "statcan:cduid":"3553",
         "wd:id":"Q383434",
         "wk:page":"Greater Sudbury"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053187,
     "wof:geom_alt":[
@@ -87,7 +89,7 @@
         }
     ],
     "wof:id":890458085,
-    "wof:lastmodified":1694498003,
+    "wof:lastmodified":1695886338,
     "wof:name":"Greater Sudbury / Grand Sudbury",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/087/890458087.geojson
+++ b/data/890/458/087/890458087.geojson
@@ -95,11 +95,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"2",
         "gp:id":29375075,
         "qs_pg:id":890799,
+        "statcan:cduid":"5951",
         "wd:id":"Q2095384",
         "wk:page":"Regional District of Bulkley-Nechako"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053187,
     "wof:geom_alt":[
@@ -116,7 +122,7 @@
         }
     ],
     "wof:id":890458087,
-    "wof:lastmodified":1694498184,
+    "wof:lastmodified":1695886534,
     "wof:name":"Bulkley-Nechako",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/089/890458089.geojson
+++ b/data/890/458/089/890458089.geojson
@@ -107,11 +107,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"173",
         "gp:id":29375076,
         "qs_pg:id":890800,
+        "statcan:cduid":"5903",
         "wd:id":"Q1700010",
         "wk:page":"Regional District of Central Kootenay"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053187,
     "wof:geom_alt":[
@@ -128,7 +134,7 @@
         }
     ],
     "wof:id":890458089,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886509,
     "wof:name":"Central Kootenay",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/091/890458091.geojson
+++ b/data/890/458/091/890458091.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375094,
         "qs_pg:id":890801,
+        "statcan:cduid":"2468",
         "wd:id":"Q528670",
         "wk:page":"Les Jardins-de-Napierville Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053188,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890458091,
-    "wof:lastmodified":1694497849,
+    "wof:lastmodified":1695886291,
     "wof:name":"Les Jardins-de-Napierville",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/093/890458093.geojson
+++ b/data/890/458/093/890458093.geojson
@@ -221,9 +221,11 @@
     "wof:concordances":{
         "gp:id":29375096,
         "qs_pg:id":890802,
+        "statcan:cduid":"3536",
         "wd:id":"Q113464",
         "wk:page":"Chatham-Kent"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053188,
     "wof:geom_alt":[
@@ -239,7 +241,7 @@
         }
     ],
     "wof:id":890458093,
-    "wof:lastmodified":1694497853,
+    "wof:lastmodified":1695886300,
     "wof:name":"Chatham-Kent",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/095/890458095.geojson
+++ b/data/890/458/095/890458095.geojson
@@ -77,8 +77,10 @@
     "wof:concordances":{
         "gp:id":29375099,
         "qs_pg:id":890803,
+        "statcan:cduid":"2464",
         "wk:page":"Les Moulins"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053188,
     "wof:geom_alt":[
@@ -94,7 +96,7 @@
         }
     ],
     "wof:id":890458095,
-    "wof:lastmodified":1694497853,
+    "wof:lastmodified":1695886300,
     "wof:name":"Les Moulins",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/097/890458097.geojson
+++ b/data/890/458/097/890458097.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375101,
         "qs_pg:id":890804,
+        "statcan:cduid":"2477",
         "wd:id":"Q773444",
         "wk:page":"Les Pays-d'en-Haut Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053188,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890458097,
-    "wof:lastmodified":1694497850,
+    "wof:lastmodified":1695886292,
     "wof:name":"Les Pays-d'en-Haut",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/099/890458099.geojson
+++ b/data/890/458/099/890458099.geojson
@@ -223,8 +223,10 @@
     "wof:concordances":{
         "gp:id":29375102,
         "qs_pg:id":890805,
+        "statcan:cduid":"1210",
         "wk:page":"Colchester"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053188,
     "wof:geom_alt":[
@@ -240,7 +242,7 @@
         }
     ],
     "wof:id":890458099,
-    "wof:lastmodified":1694497850,
+    "wof:lastmodified":1695886292,
     "wof:name":"Colchester",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/103/890458103.geojson
+++ b/data/890/458/103/890458103.geojson
@@ -63,8 +63,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375107,
-        "qs_pg:id":890806
+        "qs_pg:id":890806,
+        "statcan:cduid":"2493"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053189,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890458103,
-    "wof:lastmodified":1694498021,
+    "wof:lastmodified":1695886393,
     "wof:name":"Lac-Saint-Jean-Est",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/105/890458105.geojson
+++ b/data/890/458/105/890458105.geojson
@@ -62,8 +62,10 @@
     "wof:concordances":{
         "gp:id":29375108,
         "qs_pg:id":890807,
+        "statcan:cduid":"1314",
         "wk:page":"Restigouche"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053189,
     "wof:geom_alt":[
@@ -79,7 +81,7 @@
         }
     ],
     "wof:id":890458105,
-    "wof:lastmodified":1694497846,
+    "wof:lastmodified":1695886279,
     "wof:name":"Restigouche",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/458/107/890458107.geojson
+++ b/data/890/458/107/890458107.geojson
@@ -89,9 +89,11 @@
     "wof:concordances":{
         "gp:id":29375202,
         "qs_pg:id":890831,
+        "statcan:cduid":"2452",
         "wd:id":"Q975170",
         "wk:page":"D'Autray Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053189,
     "wof:geom_alt":[
@@ -107,7 +109,7 @@
         }
     ],
     "wof:id":890458107,
-    "wof:lastmodified":1694497851,
+    "wof:lastmodified":1695886296,
     "wof:name":"D'Autray",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/109/890458109.geojson
+++ b/data/890/458/109/890458109.geojson
@@ -143,9 +143,11 @@
     "wof:concordances":{
         "gp:id":29375206,
         "qs_pg:id":890832,
+        "statcan:cduid":"3516",
         "wd:id":"Q384755",
         "wk:page":"Kawartha Lakes"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101735495
     ],
@@ -164,7 +166,7 @@
         }
     ],
     "wof:id":890458109,
-    "wof:lastmodified":1694497947,
+    "wof:lastmodified":1695886593,
     "wof:name":"Kawartha Lakes",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/111/890458111.geojson
+++ b/data/890/458/111/890458111.geojson
@@ -92,10 +92,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"47",
         "gp:id":29375209,
         "qs_pg:id":890833,
+        "statcan:cduid":"5949",
         "wk:page":"Regional District of Kitimat-Stikine"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053189,
     "wof:geom_alt":[
@@ -112,7 +118,7 @@
         }
     ],
     "wof:id":890458111,
-    "wof:lastmodified":1694498011,
+    "wof:lastmodified":1695886363,
     "wof:name":"Kitimat-Stikine",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/113/890458113.geojson
+++ b/data/890/458/113/890458113.geojson
@@ -83,11 +83,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"235",
         "gp:id":29375210,
         "qs_pg:id":890834,
+        "statcan:cduid":"5937",
         "wd:id":"Q7056212",
         "wk:page":"North Okanagan"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053190,
     "wof:geom_alt":[
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":890458113,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886501,
     "wof:name":"North Okanagan",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/115/890458115.geojson
+++ b/data/890/458/115/890458115.geojson
@@ -104,9 +104,11 @@
     "wof:concordances":{
         "gp:id":29375226,
         "qs_pg:id":890836,
+        "statcan:cduid":"2416",
         "wd:id":"Q14875515",
         "wk:page":"Charlevoix"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053190,
     "wof:geom_alt":[
@@ -122,7 +124,7 @@
         }
     ],
     "wof:id":890458115,
-    "wof:lastmodified":1694497854,
+    "wof:lastmodified":1695886303,
     "wof:name":"Charlevoix",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/397/890458397.geojson
+++ b/data/890/458/397/890458397.geojson
@@ -167,9 +167,11 @@
     "wof:concordances":{
         "gp:id":29375113,
         "qs_pg:id":1290369,
+        "statcan:cduid":"2461",
         "wd:id":"Q141760",
         "wk:page":"Joliette"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053214,
     "wof:geom_alt":[
@@ -185,7 +187,7 @@
         }
     ],
     "wof:id":890458397,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886519,
     "wof:name":"Joliette",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/399/890458399.geojson
+++ b/data/890/458/399/890458399.geojson
@@ -389,8 +389,10 @@
     "wof:concordances":{
         "gp:id":29375115,
         "qs_pg:id":1290370,
+        "statcan:cduid":"3532",
         "wk:page":"Oxford"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053214,
     "wof:geom_alt":[
@@ -406,7 +408,7 @@
         }
     ],
     "wof:id":890458399,
-    "wof:lastmodified":1694497847,
+    "wof:lastmodified":1695886284,
     "wof:name":"Oxford",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/401/890458401.geojson
+++ b/data/890/458/401/890458401.geojson
@@ -74,8 +74,10 @@
     "wof:concordances":{
         "gp:id":29375213,
         "qs_pg:id":1290409,
+        "statcan:cduid":"2433",
         "wk:page":"Lotbini\u00e8re"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053214,
     "wof:geom_alt":[
@@ -91,7 +93,7 @@
         }
     ],
     "wof:id":890458401,
-    "wof:lastmodified":1694497850,
+    "wof:lastmodified":1695886291,
     "wof:name":"Lotbiniere",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/413/890458413.geojson
+++ b/data/890/458/413/890458413.geojson
@@ -104,8 +104,10 @@
     "wof:concordances":{
         "gp:id":29375078,
         "qs_pg:id":1291329,
+        "statcan:cduid":"3524",
         "wk:page":"Halton"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053215,
     "wof:geom_alt":[
@@ -121,7 +123,7 @@
         }
     ],
     "wof:id":890458413,
-    "wof:lastmodified":1694498184,
+    "wof:lastmodified":1695886532,
     "wof:name":"Halton",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/415/890458415.geojson
+++ b/data/890/458/415/890458415.geojson
@@ -331,8 +331,10 @@
     "wof:concordances":{
         "gp:id":29375112,
         "qs_pg:id":1291330,
+        "statcan:cduid":"3519",
         "wk:page":"York"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053215,
     "wof:geom_alt":[
@@ -348,7 +350,7 @@
         }
     ],
     "wof:id":890458415,
-    "wof:lastmodified":1694497946,
+    "wof:lastmodified":1695886571,
     "wof:name":"York",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/417/890458417.geojson
+++ b/data/890/458/417/890458417.geojson
@@ -89,9 +89,11 @@
     "wof:concordances":{
         "gp:id":29375062,
         "qs_pg:id":1291340,
+        "statcan:cduid":"2475",
         "wd:id":"Q1517943",
         "wk:page":"La Rivi\u00e8re-du-Nord Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053215,
     "wof:geom_alt":[
@@ -107,7 +109,7 @@
         }
     ],
     "wof:id":890458417,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886298,
     "wof:name":"La Riviere-du-Nord",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/419/890458419.geojson
+++ b/data/890/458/419/890458419.geojson
@@ -203,8 +203,10 @@
     "wof:concordances":{
         "gp:id":29375063,
         "qs_pg:id":1291361,
+        "statcan:cduid":"1216",
         "wk:page":"Richmond"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053215,
     "wof:geom_alt":[
@@ -220,7 +222,7 @@
         }
     ],
     "wof:id":890458419,
-    "wof:lastmodified":1694498079,
+    "wof:lastmodified":1695886448,
     "wof:name":"Richmond",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/427/890458427.geojson
+++ b/data/890/458/427/890458427.geojson
@@ -95,11 +95,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"194",
         "gp:id":29375237,
         "qs_pg:id":1316165,
+        "statcan:cduid":"5939",
         "wd:id":"Q1112324",
         "wk:page":"Columbia-Shuswap Regional District"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053215,
     "wof:geom_alt":[
@@ -116,7 +122,7 @@
         }
     ],
     "wof:id":890458427,
-    "wof:lastmodified":1694497965,
+    "wof:lastmodified":1695886237,
     "wof:name":"Columbia-Shuswap",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/465/890458465.geojson
+++ b/data/890/458/465/890458465.geojson
@@ -98,11 +98,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"151",
         "gp:id":29375074,
         "qs_pg:id":890808,
+        "statcan:cduid":"5933",
         "wd:id":"Q583957",
         "wk:page":"Thompson-Nicola Regional District"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053218,
     "wof:geom_alt":[
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":890458465,
-    "wof:lastmodified":1694498042,
+    "wof:lastmodified":1695886452,
     "wof:name":"Thompson-Nicola",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/469/890458469.geojson
+++ b/data/890/458/469/890458469.geojson
@@ -133,8 +133,10 @@
     "wof:concordances":{
         "gp:id":29375055,
         "qs_pg:id":379292,
+        "statcan:cduid":"3509",
         "wk:page":"Lanark"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053219,
     "wof:geom_alt":[
@@ -150,7 +152,7 @@
         }
     ],
     "wof:id":890458469,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886299,
     "wof:name":"Lanark",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/529/890458529.geojson
+++ b/data/890/458/529/890458529.geojson
@@ -131,8 +131,10 @@
     "wof:concordances":{
         "gp:id":29375189,
         "qs_pg:id":888319,
+        "statcan:cduid":"3534",
         "wk:page":"Elgin"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053222,
     "wof:geom_alt":[
@@ -148,7 +150,7 @@
         }
     ],
     "wof:id":890458529,
-    "wof:lastmodified":1694497851,
+    "wof:lastmodified":1695886295,
     "wof:name":"Elgin",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/535/890458535.geojson
+++ b/data/890/458/535/890458535.geojson
@@ -89,9 +89,11 @@
     "wof:concordances":{
         "gp:id":29375128,
         "qs_pg:id":890812,
+        "statcan:cduid":"2447",
         "wd:id":"Q1497865",
         "wk:page":"La Haute-Yamaska Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053222,
     "wof:geom_alt":[
@@ -107,7 +109,7 @@
         }
     ],
     "wof:id":890458535,
-    "wof:lastmodified":1694497848,
+    "wof:lastmodified":1695886286,
     "wof:name":"La Haute-Yamaska",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/537/890458537.geojson
+++ b/data/890/458/537/890458537.geojson
@@ -65,8 +65,10 @@
     "wof:concordances":{
         "gp:id":29375129,
         "qs_pg:id":890813,
+        "statcan:cduid":"1208",
         "wk:page":"Hants"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053222,
     "wof:geom_alt":[
@@ -82,7 +84,7 @@
         }
     ],
     "wof:id":890458537,
-    "wof:lastmodified":1694498006,
+    "wof:lastmodified":1695886348,
     "wof:name":"Hants",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/539/890458539.geojson
+++ b/data/890/458/539/890458539.geojson
@@ -60,8 +60,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375142,
-        "qs_pg:id":890814
+        "qs_pg:id":890814,
+        "statcan:cduid":"1213"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053222,
     "wof:geom_alt":[
@@ -77,7 +79,7 @@
         }
     ],
     "wof:id":890458539,
-    "wof:lastmodified":1694498004,
+    "wof:lastmodified":1695886339,
     "wof:name":"Guysborough",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/541/890458541.geojson
+++ b/data/890/458/541/890458541.geojson
@@ -62,8 +62,10 @@
     "wof:concordances":{
         "gp:id":29375143,
         "qs_pg:id":890815,
+        "statcan:cduid":"2439",
         "wk:page":"Arthabaska"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053223,
     "wof:geom_alt":[
@@ -79,7 +81,7 @@
         }
     ],
     "wof:id":890458541,
-    "wof:lastmodified":1694497854,
+    "wof:lastmodified":1695886303,
     "wof:name":"Arthabaska",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/543/890458543.geojson
+++ b/data/890/458/543/890458543.geojson
@@ -74,8 +74,10 @@
     "wof:concordances":{
         "gp:id":29375146,
         "qs_pg:id":890816,
+        "statcan:cduid":"2451",
         "wk:page":"Maskinong\u00e9"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053223,
     "wof:geom_alt":[
@@ -91,7 +93,7 @@
         }
     ],
     "wof:id":890458543,
-    "wof:lastmodified":1694497851,
+    "wof:lastmodified":1695886294,
     "wof:name":"Maskinonge",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/545/890458545.geojson
+++ b/data/890/458/545/890458545.geojson
@@ -86,9 +86,11 @@
     "wof:concordances":{
         "gp:id":29375150,
         "qs_pg:id":897315,
+        "statcan:cduid":"3544",
         "wd:id":"Q382508",
         "wk:page":"District Municipality of Muskoka"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053223,
     "wof:geom_alt":[
@@ -104,7 +106,7 @@
         }
     ],
     "wof:id":890458545,
-    "wof:lastmodified":1694498024,
+    "wof:lastmodified":1695886400,
     "wof:name":"Muskoka",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/565/890458565.geojson
+++ b/data/890/458/565/890458565.geojson
@@ -97,11 +97,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"280",
         "gp:id":29375117,
         "qs_pg:id":903227,
+        "statcan:cduid":"5926",
         "wd:id":"Q645582",
         "wk:page":"Comox-Strathcona Regional District"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053224,
     "wof:geom_alt":[
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890458565,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886523,
     "wof:name":"Comox Valley",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/567/890458567.geojson
+++ b/data/890/458/567/890458567.geojson
@@ -95,11 +95,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"287",
         "gp:id":29375119,
         "qs_pg:id":903228,
+        "statcan:cduid":"5919",
         "wd:id":"Q5179709",
         "wk:page":"Cowichan Valley"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053225,
     "wof:geom_alt":[
@@ -116,7 +122,7 @@
         }
     ],
     "wof:id":890458567,
-    "wof:lastmodified":1694497965,
+    "wof:lastmodified":1695886238,
     "wof:name":"Cowichan Valley",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/599/890458599.geojson
+++ b/data/890/458/599/890458599.geojson
@@ -98,11 +98,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"247",
         "gp:id":29375188,
         "qs_pg:id":212517,
+        "statcan:cduid":"5923",
         "wd:id":"Q1778727",
         "wk:page":"Alberni-Clayoquot Regional District"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053227,
     "wof:geom_alt":[
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":890458599,
-    "wof:lastmodified":1694497962,
+    "wof:lastmodified":1695886229,
     "wof:name":"Alberni-Clayoquot",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/609/890458609.geojson
+++ b/data/890/458/609/890458609.geojson
@@ -77,8 +77,10 @@
     "wof:concordances":{
         "gp:id":29375037,
         "qs_pg:id":218202,
+        "statcan:cduid":"2417",
         "wk:page":"L'Islet"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053228,
     "wof:geom_alt":[
@@ -94,7 +96,7 @@
         }
     ],
     "wof:id":890458609,
-    "wof:lastmodified":1694497853,
+    "wof:lastmodified":1695886302,
     "wof:name":"L'Islet",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/611/890458611.geojson
+++ b/data/890/458/611/890458611.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375038,
         "qs_pg:id":218203,
+        "statcan:cduid":"2430",
         "wd:id":"Q1809910",
         "wk:page":"Le Granit Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053228,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890458611,
-    "wof:lastmodified":1694497850,
+    "wof:lastmodified":1695886292,
     "wof:name":"Le Granit",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/613/890458613.geojson
+++ b/data/890/458/613/890458613.geojson
@@ -269,8 +269,10 @@
     "wof:concordances":{
         "gp:id":29375039,
         "qs_pg:id":218204,
+        "statcan:cduid":"1218",
         "wk:page":"Victoria"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053228,
     "wof:geom_alt":[
@@ -286,7 +288,7 @@
         }
     ],
     "wof:id":890458613,
-    "wof:lastmodified":1694498079,
+    "wof:lastmodified":1695886449,
     "wof:name":"Victoria",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/615/890458615.geojson
+++ b/data/890/458/615/890458615.geojson
@@ -122,9 +122,11 @@
     "wof:concordances":{
         "gp:id":29375040,
         "qs_pg:id":218205,
+        "statcan:cduid":"1212",
         "wd:id":"Q1018711",
         "wk:page":"Pictou"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053228,
     "wof:geom_alt":[
@@ -140,7 +142,7 @@
         }
     ],
     "wof:id":890458615,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886298,
     "wof:name":"Pictou",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/629/890458629.geojson
+++ b/data/890/458/629/890458629.geojson
@@ -62,8 +62,10 @@
     "wof:concordances":{
         "gp:id":29375171,
         "qs_pg:id":220443,
+        "statcan:cduid":"2470",
         "wk:page":"Beauharnois-Salaberry"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053229,
     "wof:geom_alt":[
@@ -79,7 +81,7 @@
         }
     ],
     "wof:id":890458629,
-    "wof:lastmodified":1694497964,
+    "wof:lastmodified":1695886235,
     "wof:name":"Beauharnois-Salaberry",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/631/890458631.geojson
+++ b/data/890/458/631/890458631.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375172,
         "qs_pg:id":220444,
+        "statcan:cduid":"2431",
         "wd:id":"Q1517564",
         "wk:page":"Les Appalaches Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053229,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890458631,
-    "wof:lastmodified":1694497853,
+    "wof:lastmodified":1695886302,
     "wof:name":"Les Appalaches",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/633/890458633.geojson
+++ b/data/890/458/633/890458633.geojson
@@ -89,9 +89,11 @@
     "wof:concordances":{
         "gp:id":29375173,
         "qs_pg:id":220445,
+        "statcan:cduid":"2492",
         "wd:id":"Q1517952",
         "wk:page":"Maria-Chapdelaine"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053229,
     "wof:geom_alt":[
@@ -107,7 +109,7 @@
         }
     ],
     "wof:id":890458633,
-    "wof:lastmodified":1694497850,
+    "wof:lastmodified":1695886292,
     "wof:name":"Maria-Chapdelaine",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/661/890458661.geojson
+++ b/data/890/458/661/890458661.geojson
@@ -592,9 +592,11 @@
         "gn:id":6077246,
         "gp:id":29375198,
         "qs_pg:id":224180,
+        "statcan:cduid":"2466",
         "wd:id":"Q340",
         "wk:page":"Montreal"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101736545
     ],
@@ -613,7 +615,7 @@
         }
     ],
     "wof:id":890458661,
-    "wof:lastmodified":1694497947,
+    "wof:lastmodified":1695886593,
     "wof:name":"Montreal",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/681/890458681.geojson
+++ b/data/890/458/681/890458681.geojson
@@ -647,9 +647,11 @@
     "wof:concordances":{
         "gp:id":29375164,
         "qs_pg:id":225115,
+        "statcan:cduid":"3506",
         "wd:id":"Q1930",
         "wk:page":"Ottawa"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101735873
     ],
@@ -668,7 +670,7 @@
         }
     ],
     "wof:id":890458681,
-    "wof:lastmodified":1694498078,
+    "wof:lastmodified":1695886444,
     "wof:name":"Ottawa",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/683/890458683.geojson
+++ b/data/890/458/683/890458683.geojson
@@ -294,8 +294,10 @@
     "wof:concordances":{
         "gp:id":29375056,
         "qs_pg:id":225126,
+        "statcan:cduid":"3537",
         "wk:page":"Essex"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053232,
     "wof:geom_alt":[
@@ -311,7 +313,7 @@
         }
     ],
     "wof:id":890458683,
-    "wof:lastmodified":1694497947,
+    "wof:lastmodified":1695886612,
     "wof:name":"Essex",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/685/890458685.geojson
+++ b/data/890/458/685/890458685.geojson
@@ -319,8 +319,10 @@
     "wof:concordances":{
         "gp:id":29375042,
         "qs_pg:id":225128,
+        "statcan:cduid":"1310",
         "wk:page":"York"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053232,
     "wof:geom_alt":[
@@ -336,7 +338,7 @@
         }
     ],
     "wof:id":890458685,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886298,
     "wof:name":"York",
     "wof:parent_id":85682065,
     "wof:placetype":"county",

--- a/data/890/458/687/890458687.geojson
+++ b/data/890/458/687/890458687.geojson
@@ -280,9 +280,11 @@
     "wof:concordances":{
         "gp:id":29375089,
         "qs_pg:id":225132,
+        "statcan:cduid":"3558",
         "wd:id":"Q34116",
         "wk:page":"Thunder Bay"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053232,
     "wof:geom_alt":[
@@ -298,7 +300,7 @@
         }
     ],
     "wof:id":890458687,
-    "wof:lastmodified":1694497849,
+    "wof:lastmodified":1695886288,
     "wof:name":"Thunder Bay",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/689/890458689.geojson
+++ b/data/890/458/689/890458689.geojson
@@ -63,8 +63,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29375090,
-        "qs_pg:id":225133
+        "qs_pg:id":225133,
+        "statcan:cduid":"2441"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053232,
     "wof:geom_alt":[
@@ -80,7 +82,7 @@
         }
     ],
     "wof:id":890458689,
-    "wof:lastmodified":1694498178,
+    "wof:lastmodified":1695886494,
     "wof:name":"Le Haut-Saint-Francois",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/691/890458691.geojson
+++ b/data/890/458/691/890458691.geojson
@@ -134,8 +134,10 @@
     "wof:concordances":{
         "gp:id":29375091,
         "qs_pg:id":225134,
+        "statcan:cduid":"1202",
         "wk:page":"Yarmouth"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053233,
     "wof:geom_alt":[
@@ -151,7 +153,7 @@
         }
     ],
     "wof:id":890458691,
-    "wof:lastmodified":1694498080,
+    "wof:lastmodified":1695886451,
     "wof:name":"Yarmouth",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/693/890458693.geojson
+++ b/data/890/458/693/890458693.geojson
@@ -83,9 +83,11 @@
     "wof:concordances":{
         "gp:id":29375092,
         "qs_pg:id":225135,
+        "statcan:cduid":"2453",
         "wd:id":"Q1517640",
         "wk:page":"Pierre-De Saurel Regional County Municipality"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053233,
     "wof:geom_alt":[
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890458693,
-    "wof:lastmodified":1694497850,
+    "wof:lastmodified":1695886293,
     "wof:name":"Pierre-De Saurel",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/697/890458697.geojson
+++ b/data/890/458/697/890458697.geojson
@@ -107,11 +107,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"82",
         "gp:id":29375224,
         "qs_pg:id":225136,
+        "statcan:cduid":"5935",
         "wd:id":"Q945201",
         "wk:page":"Regional District of Central Okanagan"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053233,
     "wof:geom_alt":[
@@ -128,7 +134,7 @@
         }
     ],
     "wof:id":890458697,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886524,
     "wof:name":"Central Okanagan",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/765/890458765.geojson
+++ b/data/890/458/765/890458765.geojson
@@ -116,8 +116,10 @@
     "wof:concordances":{
         "gp:id":29375057,
         "qs_pg:id":232965,
+        "statcan:cduid":"3540",
         "wk:page":"Huron"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053237,
     "wof:geom_alt":[
@@ -133,7 +135,7 @@
         }
     ],
     "wof:id":890458765,
-    "wof:lastmodified":1694497846,
+    "wof:lastmodified":1695886280,
     "wof:name":"Huron",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/777/890458777.geojson
+++ b/data/890/458/777/890458777.geojson
@@ -125,8 +125,10 @@
     "wof:concordances":{
         "gp:id":29375177,
         "qs_pg:id":988474,
+        "statcan:cduid":"3552",
         "wk:page":"Sudbury"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053238,
     "wof:geom_alt":[
@@ -142,7 +144,7 @@
         }
     ],
     "wof:id":890458777,
-    "wof:lastmodified":1694498078,
+    "wof:lastmodified":1695886446,
     "wof:name":"Sudbury",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/809/890458809.geojson
+++ b/data/890/458/809/890458809.geojson
@@ -107,9 +107,11 @@
     "wof:concordances":{
         "gp:id":29375048,
         "qs_pg:id":237966,
+        "statcan:cduid":"3551",
         "wd:id":"Q1815566",
         "wk:page":"Manitoulin District"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053239,
     "wof:geom_alt":[
@@ -125,7 +127,7 @@
         }
     ],
     "wof:id":890458809,
-    "wof:lastmodified":1694498023,
+    "wof:lastmodified":1695886398,
     "wof:name":"Manitoulin",
     "wof:parent_id":85682057,
     "wof:placetype":"county",

--- a/data/890/458/811/890458811.geojson
+++ b/data/890/458/811/890458811.geojson
@@ -116,8 +116,10 @@
     "wof:concordances":{
         "gp:id":29375049,
         "qs_pg:id":237967,
+        "statcan:cduid":"1203",
         "wk:page":"Digby"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053239,
     "wof:geom_alt":[
@@ -133,7 +135,7 @@
         }
     ],
     "wof:id":890458811,
-    "wof:lastmodified":1694498078,
+    "wof:lastmodified":1695886445,
     "wof:name":"Digby",
     "wof:parent_id":85682075,
     "wof:placetype":"county",

--- a/data/890/458/841/890458841.geojson
+++ b/data/890/458/841/890458841.geojson
@@ -71,8 +71,10 @@
     "wof:concordances":{
         "gp:id":29375184,
         "qs_pg:id":239316,
+        "statcan:cduid":"2438",
         "wk:page":"B\u00e9cancour"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:country":"CA",
     "wof:created":1469053241,
     "wof:geom_alt":[
@@ -88,7 +90,7 @@
         }
     ],
     "wof:id":890458841,
-    "wof:lastmodified":1694497852,
+    "wof:lastmodified":1695886297,
     "wof:name":"Bcancour",
     "wof:parent_id":136251273,
     "wof:placetype":"county",

--- a/data/890/458/867/890458867.geojson
+++ b/data/890/458/867/890458867.geojson
@@ -98,11 +98,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "can-databc:aa_id":"89",
         "gp:id":29375118,
         "qs_pg:id":242099,
+        "statcan:cduid":"5909",
         "wd:id":"Q3554074",
         "wk:page":"Fraser Valley"
     },
+    "wof:concordances_official":"statcan:cduid",
+    "wof:concordances_official_alt":[
+        "can-databc:aa_id"
+    ],
     "wof:country":"CA",
     "wof:created":1469053242,
     "wof:geom_alt":[
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":890458867,
-    "wof:lastmodified":1694497851,
+    "wof:lastmodified":1695886294,
     "wof:name":"Fraser Valley",
     "wof:parent_id":85682117,
     "wof:placetype":"county",

--- a/data/890/458/877/890458877.geojson
+++ b/data/890/458/877/890458877.geojson
@@ -260,9 +260,11 @@
     "wof:concordances":{
         "gp:id":29375034,
         "qs_pg:id":1320739,
+        "statcan:cduid":"2425",
         "wd:id":"Q139208",
         "wk:page":"L\u00e9vis, Quebec"
     },
+    "wof:concordances_official":"statcan:cduid",
     "wof:coterminous":[
         101737987
     ],
@@ -281,7 +283,7 @@
         }
     ],
     "wof:id":890458877,
-    "wof:lastmodified":1694497946,
+    "wof:lastmodified":1695886582,
     "wof:name":"Levis",
     "wof:parent_id":136251273,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.